### PR TITLE
style: sort imports flagged by ruff 0.16 I001 (v4)

### DIFF
--- a/v4/packages/kubeintellect-server/app/agent/nodes/coordinator.py
+++ b/v4/packages/kubeintellect-server/app/agent/nodes/coordinator.py
@@ -979,7 +979,10 @@ def _verify_resolution(namespace: str | None, pre_state: dict | None = None) -> 
     if not settings.REFLEXION_VERIFY_RESOLUTION:
         return None, None
     try:
-        from app.agent.nodes.context_fetcher import _run_kubectl_snapshot, _scan_snapshot
+        from app.agent.nodes.context_fetcher import (
+            _run_kubectl_snapshot,
+            _scan_snapshot,
+        )
 
         # Wait for any rolling deployment to settle before snapshotting.
         # Without this, freshly-applied fixes get penalised for transitional

--- a/v4/packages/kubeintellect-server/app/agent/workflow.py
+++ b/v4/packages/kubeintellect-server/app/agent/workflow.py
@@ -42,9 +42,9 @@ from app.streaming.emitter import (
     ErrorEvent,
     HitlRequestEvent,
     StatusEvent,
+    TokenEvent,
     ToolCallEvent,
     ToolResultEvent,
-    TokenEvent,
     close_session,
     emit,
 )
@@ -232,6 +232,7 @@ async def init_graph() -> None:
             builder = build_graph()
         if settings.USE_SQLITE:
             from pathlib import Path
+
             from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
             db_path = str(Path(settings.SQLITE_PATH).expanduser())
             Path(db_path).parent.mkdir(parents=True, exist_ok=True)

--- a/v4/packages/kubeintellect-server/app/autonomy/watchtower.py
+++ b/v4/packages/kubeintellect-server/app/autonomy/watchtower.py
@@ -121,8 +121,8 @@ async def _investigate(finding: Finding, level: str) -> None:
             f" level={level} auto_fix={auto_fix} session={session_id}"
         )
         try:
-            from app.streaming.emitter import prepare_session, stream
             from app.agent.workflow import run_session
+            from app.streaming.emitter import prepare_session, stream
 
             prepare_session(session_id)
             runner = asyncio.create_task(run_session(

--- a/v4/packages/kubeintellect-server/app/cli.py
+++ b/v4/packages/kubeintellect-server/app/cli.py
@@ -19,7 +19,6 @@ from collections import namedtuple
 from collections.abc import Callable
 from pathlib import Path
 
-
 _CONFIG_DIR = Path.home() / ".kubeintellect"
 _CONFIG_FILE = _CONFIG_DIR / ".env"
 
@@ -1539,8 +1538,8 @@ def _ensure_tool(name: str, installer: Callable[[], None]) -> None:
 
 
 def _install_kind() -> None:
-    import urllib.request
     import platform
+    import urllib.request
     arch = "amd64" if platform.machine() in ("x86_64", "AMD64") else "arm64"
     system = platform.system().lower()
     url = f"https://kind.sigs.k8s.io/dl/v0.23.0/kind-{system}-{arch}"
@@ -1550,8 +1549,8 @@ def _install_kind() -> None:
 
 
 def _install_kubectl() -> None:
-    import urllib.request
     import platform
+    import urllib.request
     arch = "amd64" if platform.machine() in ("x86_64", "AMD64") else "arm64"
     system = platform.system().lower()
     stable = urllib.request.urlopen("https://dl.k8s.io/release/stable.txt").read().decode().strip()

--- a/v4/packages/kubeintellect-server/app/core/version.py
+++ b/v4/packages/kubeintellect-server/app/core/version.py
@@ -16,7 +16,8 @@ running instance.
 
 from __future__ import annotations
 
-from importlib.metadata import PackageNotFoundError, version as _pkg_version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 
 from app.core.config import settings
 

--- a/v4/packages/kubeintellect-server/app/cortex/graph.py
+++ b/v4/packages/kubeintellect-server/app/cortex/graph.py
@@ -394,7 +394,10 @@ async def remember(state: CortexState, config: RunnableConfig) -> dict:
     deserve recall later — they get a lightweight report_only episode.
     """
     try:
-        from app.agent.nodes.coordinator import _maybe_record_direct_outcome, _ran_mutation
+        from app.agent.nodes.coordinator import (
+            _maybe_record_direct_outcome,
+            _ran_mutation,
+        )
         turn_messages = list(state["messages"])[state.get("turn_start_index", 0):]
         mutated, mut_cmds = _ran_mutation(turn_messages)
         if mutated:
@@ -429,7 +432,10 @@ async def remember(state: CortexState, config: RunnableConfig) -> dict:
             ))
             # Investigation write-back (P2): reinforce the topology from what this turn observed.
             if settings.CORTEX_V5_ENABLED and settings.KI_V5_INVESTIGATION_WRITEBACK:
-                from app.memory.writeback import apply_writeback, signals_from_investigation
+                from app.memory.writeback import (
+                    apply_writeback,
+                    signals_from_investigation,
+                )
                 signals = signals_from_investigation(
                     cluster_id, list(state.get("matched_playbooks") or []))
                 if signals:

--- a/v4/packages/kubeintellect-server/app/cortex/harness/runner.py
+++ b/v4/packages/kubeintellect-server/app/cortex/harness/runner.py
@@ -26,8 +26,12 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.runnables import RunnableConfig
 
-from app.cortex.harness.subagent import SubagentContract, SubagentResult, finalize_result
 from app.core.config import settings
+from app.cortex.harness.subagent import (
+    SubagentContract,
+    SubagentResult,
+    finalize_result,
+)
 from app.tools.aci import ACI_READ_VERBS
 from app.utils.logger import get_logger
 
@@ -168,7 +172,9 @@ async def run_fanout(
     Returns a single evidence-bundle AIMessage (no tool_calls ⇒ the graph routes straight to
     synthesize, which concludes from the fan-out evidence). ``runner`` is injectable for tests.
     """
-    from app.cortex.graph import gather_once  # lazy: avoids a graph<->runner import cycle.
+    from app.cortex.graph import (
+        gather_once,  # lazy: avoids a graph<->runner import cycle.
+    )
 
     contracts = plan_subagents(state, settings.KI_V5_HARNESS_MAX_SUBAGENTS)
     if not contracts:

--- a/v4/packages/kubeintellect-server/app/cortex/models.py
+++ b/v4/packages/kubeintellect-server/app/cortex/models.py
@@ -23,7 +23,9 @@ logger = get_logger(__name__)
 
 def _anthropic(model: str, streaming: bool) -> BaseChatModel:
     try:
-        from langchain_anthropic import ChatAnthropic  # type: ignore[import-not-found]  # optional extra
+        from langchain_anthropic import (  # type: ignore[import-not-found]  # optional extra
+            ChatAnthropic,
+        )
     except ImportError as exc:
         raise RuntimeError(
             "LLM_PROVIDER=anthropic requires the anthropic extra: "

--- a/v4/packages/kubeintellect-server/app/main.py
+++ b/v4/packages/kubeintellect-server/app/main.py
@@ -162,5 +162,6 @@ app.add_middleware(
 app.add_middleware(RequestLoggingMiddleware)
 
 from app.api.v1.endpoints.health import router as health_router
+
 app.include_router(health_router)          # /healthz — probe path (no version prefix)
 app.include_router(api_router, prefix=settings.API_V1_STR)

--- a/v4/packages/kubeintellect-server/app/streaming/emitter.py
+++ b/v4/packages/kubeintellect-server/app/streaming/emitter.py
@@ -25,8 +25,6 @@ from __future__ import annotations
 
 import asyncio
 
-from app.db import flight_recorder
-
 # Event models live in the shared ki-protocol package since the V4 monorepo
 # merge (ADR-004); re-exported here so existing imports keep working.
 from ki_protocol.wire import (
@@ -41,6 +39,8 @@ from ki_protocol.wire import (
     ToolCallEvent,
     ToolResultEvent,
 )
+
+from app.db import flight_recorder
 
 __all__ = [
     "PROTOCOL_VERSION",

--- a/v4/packages/kubeintellect-server/app/tools/kubectl_tool.py
+++ b/v4/packages/kubeintellect-server/app/tools/kubectl_tool.py
@@ -16,12 +16,12 @@ import os
 import re
 import shlex
 import subprocess
+from typing import Annotated
 
 import yaml
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import InjectedToolArg, tool
 from langgraph.types import interrupt
-from typing import Annotated
 
 from app.core.config import settings
 from app.tools import kubectl_errors

--- a/v4/scripts/aci_mutating_probe.py
+++ b/v4/scripts/aci_mutating_probe.py
@@ -11,7 +11,11 @@ from __future__ import annotations
 import os
 import sys
 
-from app.autonomy.budget import BudgetDecision, disengage_kill_switch, engage_kill_switch
+from app.autonomy.budget import (
+    BudgetDecision,
+    disengage_kill_switch,
+    engage_kill_switch,
+)
 from app.core.config import settings
 from app.tools.aci.mutating import (
     IRREVERSIBLE,

--- a/v4/scripts/aci_transactional_probe.py
+++ b/v4/scripts/aci_transactional_probe.py
@@ -12,7 +12,11 @@ import os
 import sys
 
 from app.core.config import settings
-from app.tools.aci.postcondition import PostconditionResult, deployment_ready, parse_ready_column
+from app.tools.aci.postcondition import (
+    PostconditionResult,
+    deployment_ready,
+    parse_ready_column,
+)
 from app.tools.aci.transactional import COMMITTED, ROLLED_BACK, execute_transactional
 
 FAIL: list[str] = []

--- a/v4/scripts/check_doc_claims.py
+++ b/v4/scripts/check_doc_claims.py
@@ -41,7 +41,9 @@ class Canonical:
 
 def _canonical() -> Canonical:
     """Return the authoritative values the docs must agree with."""
-    from app.agent.playbooks.loader import list_playbooks  # type: ignore[import-untyped]
+    from app.agent.playbooks.loader import (
+        list_playbooks,  # type: ignore[import-untyped]
+    )
     from app.core.config import Settings  # type: ignore[import-untyped]
     from app.detectors.engine import load_detectors  # type: ignore[import-untyped]
 

--- a/v4/scripts/cortex_flagon_probe.py
+++ b/v4/scripts/cortex_flagon_probe.py
@@ -17,10 +17,9 @@ import asyncio
 import os
 import sys
 
-from langchain_core.messages import HumanMessage
-
 from app.agent.state import PlanStep
 from app.core.config import settings
+from langchain_core.messages import HumanMessage
 
 FAIL: list[str] = []
 

--- a/v4/scripts/fleet_store_probe.py
+++ b/v4/scripts/fleet_store_probe.py
@@ -13,7 +13,6 @@ import os
 import sys
 
 import asyncpg
-
 from app.memory.fleet_exchange import FleetEntry
 from app.memory.fleet_store_pg import publish, read_fleet
 

--- a/v4/scripts/promotion_source_probe.py
+++ b/v4/scripts/promotion_source_probe.py
@@ -13,7 +13,6 @@ import os
 import sys
 
 import asyncpg
-
 from app.autonomy.promotion_source import decide_from_store, record_outcome
 from app.autonomy.promotion_stats import Event
 

--- a/v4/tests/test_aci_mutating.py
+++ b/v4/tests/test_aci_mutating.py
@@ -2,8 +2,11 @@
 from __future__ import annotations
 
 import pytest
-
-from app.autonomy.budget import BudgetDecision, disengage_kill_switch, engage_kill_switch
+from app.autonomy.budget import (
+    BudgetDecision,
+    disengage_kill_switch,
+    engage_kill_switch,
+)
 from app.tools.aci.mutating import (
     DECLARATIVE_REVERT,
     IRREVERSIBLE,

--- a/v4/tests/test_aci_v0.py
+++ b/v4/tests/test_aci_v0.py
@@ -4,15 +4,14 @@ is patched, so these run without a live cluster."""
 from __future__ import annotations
 
 import pytest
-
 from app.tools.aci import (
     ACI_READ_VERB_ALLOWLIST,
     diff_change,
     inspect,
     logs,
+    read_verbs,
     search,
 )
-from app.tools.aci import read_verbs
 from app.tools.aci.bounds import empty_message, is_read_only, normalize_krm, window
 from app.tools.aci.models import AciContractError, AciResult, Health
 

--- a/v4/tests/test_aggregate.py
+++ b/v4/tests/test_aggregate.py
@@ -1,10 +1,8 @@
 """Unit tests for evaluation/scorers/aggregate.py."""
 from __future__ import annotations
 
-
 from evaluation.models import AgentTelemetry, SignalScores, TraceIssue
 from evaluation.scorers.aggregate import WEIGHTS, WEIGHTS_WITH_VERIFY, aggregate
-
 
 # ── Weight invariants ─────────────────────────────────────────────────────────
 

--- a/v4/tests/test_api.py
+++ b/v4/tests/test_api.py
@@ -14,7 +14,6 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
 
@@ -25,8 +24,8 @@ def app():
     async def noop_lifespan(a):
         yield
 
-    from app.api.v1.router import api_router
     from app.api.v1.endpoints.health import router as health_router
+    from app.api.v1.router import api_router
 
     test_app = FastAPI(lifespan=noop_lifespan)
     test_app.include_router(health_router)

--- a/v4/tests/test_briefs.py
+++ b/v4/tests/test_briefs.py
@@ -1,12 +1,15 @@
 """Escalation-avoidance briefs (v5 P2, A-CH-17-07) — build (fail-safe) + render + wiring."""
 from __future__ import annotations
 
-from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
-
 from app.cortex import briefs as bm
 from app.cortex import graph as cx
-from app.cortex.briefs import EscalationBrief, build_brief, render_brief
-from app.cortex.briefs import _FALLBACK_ESCALATE_IF
+from app.cortex.briefs import (
+    _FALLBACK_ESCALATE_IF,
+    EscalationBrief,
+    build_brief,
+    render_brief,
+)
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 
 class _LLM:

--- a/v4/tests/test_budget_gate.py
+++ b/v4/tests/test_budget_gate.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import pytest
-
 from app.autonomy.budget import (
     auto_write_permitted,
     check_spend,

--- a/v4/tests/test_change_ledger.py
+++ b/v4/tests/test_change_ledger.py
@@ -2,13 +2,12 @@
 from __future__ import annotations
 
 import pytest
-
 from app.cortex.change_rca import recent_changes, render_change_prior
 from app.memory.change_ledger import (
     _clear,
     parse_kubectl_change,
-    record_from_commands,
     recent,
+    record_from_commands,
 )
 
 

--- a/v4/tests/test_change_rca.py
+++ b/v4/tests/test_change_rca.py
@@ -1,8 +1,6 @@
 """Change-first RCA policy (v5 P2, A-CH-02-07) — rank + render + pluggable source + injection."""
 from __future__ import annotations
 
-from langchain_core.messages import HumanMessage
-
 from app.cortex import graph as cx
 from app.cortex.change_rca import (
     ChangeRecord,
@@ -12,6 +10,7 @@ from app.cortex.change_rca import (
     render_change_prior,
     set_change_source,
 )
+from langchain_core.messages import HumanMessage
 
 _CHANGES = [
     ChangeRecord(kind="image", target="deploy/web", ts_epoch=100.0, namespace="demo", detail=":v2 -> :v3"),

--- a/v4/tests/test_change_watchdog.py
+++ b/v4/tests/test_change_watchdog.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import pytest
-
 from app.cortex.change_rca import ChangeRecord
 from app.sensorium.change_watchdog import (
     WatchdogTask,

--- a/v4/tests/test_compare.py
+++ b/v4/tests/test_compare.py
@@ -77,8 +77,9 @@ def test_load_run_includes_judge_total_from_scores_json(tmp_path):
 # ── Task 12: Table computation tests ─────────────────────────────────────────
 
 def _make_run_summary(version, records_data):
-    from evaluation.compare import RunRecord, RunSummary
     from pathlib import Path
+
+    from evaluation.compare import RunRecord, RunSummary
     records = [
         RunRecord(
             scenario_id=r["id"], version=version, category=r["cat"],

--- a/v4/tests/test_context_fetcher.py
+++ b/v4/tests/test_context_fetcher.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from app.agent.nodes.context_fetcher import _scan_snapshot
 
-
 HEALTHY_PODS = """\
 NAMESPACE     NAME                              READY   STATUS    RESTARTS   AGE
 default       app-1                             1/1     Running   0          2h

--- a/v4/tests/test_coordinator.py
+++ b/v4/tests/test_coordinator.py
@@ -7,12 +7,11 @@ without a real graph, and without Postgres.
 The coordinator node itself (LLM + tool calls) is not unit-tested here;
 that belongs in integration / eval tests against a real cluster.
 """
+from app.agent.state import AgentFinding, RCAResult
+from app.agent.workflow import route_coordinator
 from langchain_core.messages import HumanMessage
 from langgraph.graph import END
 from langgraph.types import Send
-
-from app.agent.state import AgentFinding, RCAResult
-from app.agent.workflow import route_coordinator
 
 
 def _state(**overrides) -> dict:

--- a/v4/tests/test_cortex.py
+++ b/v4/tests/test_cortex.py
@@ -1,10 +1,9 @@
 """Cortex V4 graph — triage parsing, routing, tool loop, plan transitions (P4)."""
 from __future__ import annotations
 
-from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
-
 from app.agent.state import PlanStep
 from app.cortex import graph as cx
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 
 def _state(**over):

--- a/v4/tests/test_detectors.py
+++ b/v4/tests/test_detectors.py
@@ -259,9 +259,8 @@ class TestJsonStream:
 
 class TestFindingsEndpoint:
     async def test_findings_disabled(self, mocker):
-        from httpx import ASGITransport, AsyncClient
-
         from app.main import app
+        from httpx import ASGITransport, AsyncClient
 
         mocker.patch("app.api.v1.endpoints.findings.get_engine", return_value=None)
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
@@ -270,9 +269,8 @@ class TestFindingsEndpoint:
         assert response.json()["sensorium"] == "disabled"
 
     async def test_findings_active(self, mocker):
-        from httpx import ASGITransport, AsyncClient
-
         from app.main import app
+        from httpx import ASGITransport, AsyncClient
 
         mocker.patch("app.detectors.engine.flight_recorder.record")
         engine = _engine({**CRASHLOOP, "debounce_seconds": 0})

--- a/v4/tests/test_digest.py
+++ b/v4/tests/test_digest.py
@@ -90,9 +90,8 @@ class TestDigestBuilder:
 
 class TestDigestEndpoint:
     async def test_endpoint_json_and_markdown(self, mocker):
-        from httpx import ASGITransport, AsyncClient
-
         from app.main import app
+        from httpx import ASGITransport, AsyncClient
 
         mocker.patch.object(builder, "_get_pool", return_value=FakePool())
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:

--- a/v4/tests/test_fleet_exchange.py
+++ b/v4/tests/test_fleet_exchange.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import pytest
-
 from app.memory.fleet_exchange import FleetEntry, _clear, publish, read_fleet, tenants
 
 

--- a/v4/tests/test_fleet_store_pg.py
+++ b/v4/tests/test_fleet_store_pg.py
@@ -1,7 +1,6 @@
 """Postgres-backed fleet store (v5 P5) — query construction + tenant-isolation predicate."""
 from __future__ import annotations
 
-
 from app.memory.fleet_exchange import FleetEntry
 from app.memory.fleet_store_pg import publish, read_fleet
 

--- a/v4/tests/test_flight_recorder.py
+++ b/v4/tests/test_flight_recorder.py
@@ -5,7 +5,6 @@ import asyncio
 import json
 import time
 
-
 from app.db import flight_recorder as fr
 
 
@@ -140,9 +139,8 @@ class TestEmitterIntegration:
 
 class TestReplayEndpoint:
     async def test_replay_streams_meta_and_events(self, mocker):
-        from httpx import ASGITransport, AsyncClient
-
         from app.main import app
+        from httpx import ASGITransport, AsyncClient
 
         rows = _build_chain(SAMPLE, episode_id="ep-replay")
         mocker.patch("app.api.v1.endpoints.episodes.fetch_episode", return_value=rows)
@@ -162,9 +160,8 @@ class TestReplayEndpoint:
         assert [f["type"] for f in frames[1:]] == [k for k, _ in SAMPLE]
 
     async def test_replay_flags_broken_chain(self, mocker):
-        from httpx import ASGITransport, AsyncClient
-
         from app.main import app
+        from httpx import ASGITransport, AsyncClient
 
         rows = _build_chain(SAMPLE, episode_id="ep-bad")
         rows[1]["payload"] = {"type": "tool_call", "tool": "run_kubectl", "command": "tampered"}
@@ -176,9 +173,8 @@ class TestReplayEndpoint:
         assert meta["chain_valid"] is False
 
     async def test_replay_unknown_episode_404(self, mocker):
-        from httpx import ASGITransport, AsyncClient
-
         from app.main import app
+        from httpx import ASGITransport, AsyncClient
 
         mocker.patch("app.api.v1.endpoints.episodes.fetch_episode", return_value=[])
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:

--- a/v4/tests/test_harness_runner.py
+++ b/v4/tests/test_harness_runner.py
@@ -7,8 +7,6 @@ isolation + all-fail fallback to flat gather).
 from __future__ import annotations
 
 import pytest
-from langchain_core.messages import AIMessage, HumanMessage
-
 from app.agent.state import PlanStep
 from app.cortex import graph as cx
 from app.cortex.harness import (
@@ -17,7 +15,12 @@ from app.cortex.harness import (
     run_fanout,
     run_subagent,
 )
-from app.cortex.harness.subagent import ACI_READ_VERB_ALLOWLIST, SubagentContract, SubagentResult
+from app.cortex.harness.subagent import (
+    ACI_READ_VERB_ALLOWLIST,
+    SubagentContract,
+    SubagentResult,
+)
+from langchain_core.messages import AIMessage, HumanMessage
 
 
 def _state(**over):

--- a/v4/tests/test_harness_subagent.py
+++ b/v4/tests/test_harness_subagent.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from app.cortex.harness import (
     SubagentContract,
     bound_summary,

--- a/v4/tests/test_helm_tool.py
+++ b/v4/tests/test_helm_tool.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from app.tools.helm_tool import run_helm
 
 

--- a/v4/tests/test_hitl_session.py
+++ b/v4/tests/test_hitl_session.py
@@ -6,7 +6,6 @@ or Postgres connection.
 """
 import pytest
 
-
 # ── Approval / denial detection ───────────────────────────────────────────────
 
 class TestApprovalDetection:
@@ -77,8 +76,9 @@ class TestSessionIDHandling:
         )
 
     def _make_request(self, headers=None):
+        from unittest.mock import AsyncMock, patch
+
         from fastapi.testclient import TestClient
-        from unittest.mock import patch, AsyncMock
 
         async def fake_run(*args, **kwargs):
             pass
@@ -102,7 +102,7 @@ class TestSessionIDHandling:
 
     def test_session_id_from_header_is_used(self):
         """When X-Session-ID is present, emitter_stream must receive that exact value."""
-        from unittest.mock import patch, AsyncMock
+        from unittest.mock import AsyncMock, patch
         captured = {}
 
         async def fake_run(*args, **kwargs):
@@ -117,8 +117,8 @@ class TestSessionIDHandling:
              patch("app.api.v1.endpoints.chat_completions.prepare_session"), \
              patch("app.api.v1.endpoints.chat_completions.emitter_stream", side_effect=fake_emitter), \
              patch("app.api.v1.endpoints.chat_completions._audit_log", new_callable=AsyncMock):
-            from fastapi.testclient import TestClient
             from app.main import app
+            from fastapi.testclient import TestClient
             client = TestClient(app)
             client.post(
                 "/v1/chat/completions",
@@ -130,7 +130,7 @@ class TestSessionIDHandling:
     def test_missing_session_id_generates_uuid(self):
         """Without X-Session-ID, a fresh UUID must be generated per request."""
         import re
-        from unittest.mock import patch, AsyncMock
+        from unittest.mock import AsyncMock, patch
         captured_ids = []
 
         async def fake_run(*args, **kwargs):
@@ -145,8 +145,8 @@ class TestSessionIDHandling:
              patch("app.api.v1.endpoints.chat_completions.prepare_session"), \
              patch("app.api.v1.endpoints.chat_completions.emitter_stream", side_effect=fake_emitter), \
              patch("app.api.v1.endpoints.chat_completions._audit_log", new_callable=AsyncMock):
-            from fastapi.testclient import TestClient
             from app.main import app
+            from fastapi.testclient import TestClient
             client = TestClient(app)
             for _ in range(2):
                 client.post(

--- a/v4/tests/test_kg.py
+++ b/v4/tests/test_kg.py
@@ -6,10 +6,8 @@ import uuid
 from datetime import datetime, timedelta, timezone
 
 import pytest
-
 from app.memory import kg
 from app.sensorium.observations import Observation
-
 
 # ── Fakes ─────────────────────────────────────────────────────────────────────
 

--- a/v4/tests/test_kubectl_errors.py
+++ b/v4/tests/test_kubectl_errors.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import pytest
-
 from app.tools import kubectl_errors
 
 

--- a/v4/tests/test_kubectl_tool.py
+++ b/v4/tests/test_kubectl_tool.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
 # ── Shell injection guard ─────────────────────────────────────────────────────
 
 class TestShellInjectionGuard:

--- a/v4/tests/test_lofa_l2_replay.py
+++ b/v4/tests/test_lofa_l2_replay.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import time
 
 import pytest
-
 from app.detectors.engine import DetectorEngine, load_detectors
 from app.sensorium.observations import Observation
 

--- a/v4/tests/test_loki_telemetry.py
+++ b/v4/tests/test_loki_telemetry.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 
 import json
 
-
+from evaluation.collectors.loki_collector import _parse_log_line, parse_telemetry
 from evaluation.models import LokiLogLine, LokiLogs
-from evaluation.collectors.loki_collector import parse_telemetry, _parse_log_line
-
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/v4/tests/test_memory_security.py
+++ b/v4/tests/test_memory_security.py
@@ -6,7 +6,6 @@ AC-D8: a MINJA-style query-only injection targeting memory is blocked at write.
 from __future__ import annotations
 
 import pytest
-
 from app.memory import episodes, security
 
 

--- a/v4/tests/test_nl_detector_authoring.py
+++ b/v4/tests/test_nl_detector_authoring.py
@@ -151,10 +151,9 @@ class TestStageAndPromote:
 
 class TestEndpoint:
     async def test_disabled_returns_404(self, mocker):
-        from httpx import ASGITransport, AsyncClient
-
         from app.api.v1.endpoints import detectors as ep
         from app.main import app
+        from httpx import ASGITransport, AsyncClient
 
         mocker.patch.object(ep.settings, "NL_DETECTOR_AUTHORING_ENABLED", False)
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:

--- a/v4/tests/test_opsmembench.py
+++ b/v4/tests/test_opsmembench.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from app.eval.opsmembench import (
     GradeArtifact,
     HarnessSpec,

--- a/v4/tests/test_playbooks.py
+++ b/v4/tests/test_playbooks.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from app.agent.playbooks import get_playbook, list_playbooks, match_playbooks
 
-
 CRASHLOOP_PODS = """\
 NAMESPACE   NAME    READY   STATUS             RESTARTS   AGE
 default     app-1   0/1     CrashLoopBackOff   5          10m

--- a/v4/tests/test_postmortem.py
+++ b/v4/tests/test_postmortem.py
@@ -138,9 +138,8 @@ class TestNarrative:
 
 class TestPostmortemEndpoint:
     async def test_endpoint_json_and_markdown(self, mocker):
-        from httpx import ASGITransport, AsyncClient
-
         from app.main import app
+        from httpx import ASGITransport, AsyncClient
 
         _patch_fetch(mocker, _chain("ep-1", _EVENTS))
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:

--- a/v4/tests/test_promotion_engine.py
+++ b/v4/tests/test_promotion_engine.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import pytest
-
 from app.autonomy.promotion_engine import (
     _empty_source,
     decide,

--- a/v4/tests/test_promotion_stats.py
+++ b/v4/tests/test_promotion_stats.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from app.autonomy.promotion_stats import (
     Event,
     evaluate_promotion,

--- a/v4/tests/test_reflexion.py
+++ b/v4/tests/test_reflexion.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from langchain_core.messages import AIMessage, HumanMessage
 
-
 # ── R8: secret redaction ──────────────────────────────────────────────────────
 
 

--- a/v4/tests/test_repair.py
+++ b/v4/tests/test_repair.py
@@ -1,9 +1,8 @@
 """Misconfig auto-repair (v5 P3) — LLM fix proposal, fail-safe."""
 from __future__ import annotations
 
-from langchain_core.messages import AIMessage
-
 from app.tools.aci.repair import _strip_fences, propose_fix
+from langchain_core.messages import AIMessage
 
 _ORIG = "apiVersion: apps/v1\nkind: Deployment\nspec:\n  securityContext:\n    runAsNonRoot: false\n"
 _FIXED = "apiVersion: apps/v1\nkind: Deployment\nspec:\n  securityContext:\n    runAsNonRoot: true\n"

--- a/v4/tests/test_responsiveness.py
+++ b/v4/tests/test_responsiveness.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 
 import asyncio
 
-from langchain_core.messages import AIMessage, ToolMessage
-
 from app.agent.state import PlanStep
 from app.cortex import graph as cx
 from app.cortex.responsiveness import PhaseBudget, heartbeat
+from langchain_core.messages import AIMessage, ToolMessage
 
 
 class _Clock:

--- a/v4/tests/test_runbook_skills.py
+++ b/v4/tests/test_runbook_skills.py
@@ -1,11 +1,10 @@
 """Runbooks-as-skills v0 (v5 P2) — on-demand rendering + gather-prompt injection."""
 from __future__ import annotations
 
-from langchain_core.messages import HumanMessage
-
 from app.agent.playbooks.loader import Playbook
 from app.cortex import graph as cx
 from app.cortex.skills import render_matched_skills, render_skill
+from langchain_core.messages import HumanMessage
 
 
 def test_render_skill_has_all_sections():

--- a/v4/tests/test_signal_scorer.py
+++ b/v4/tests/test_signal_scorer.py
@@ -1,9 +1,7 @@
 """Unit tests for evaluation/scorers/signal_scorer.py."""
 from __future__ import annotations
 
-
 from evaluation.models import EvalResult, LangfuseTrace, LokiLogs
-
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/v4/tests/test_v5_status.py
+++ b/v4/tests/test_v5_status.py
@@ -1,12 +1,11 @@
 """GET /v5/status — v5 trust-plane observability endpoint."""
 from __future__ import annotations
 
-from fastapi import FastAPI
-from starlette.testclient import TestClient
-
 from app.api.v1.endpoints.v5_status import router
 from app.autonomy.budget import disengage_kill_switch, engage_kill_switch
 from app.core.config import settings
+from fastapi import FastAPI
+from starlette.testclient import TestClient
 
 
 def _client():

--- a/v4/tests/test_verify_ladder.py
+++ b/v4/tests/test_verify_ladder.py
@@ -4,8 +4,6 @@ Fake-LLM unit tests (no network) plus the synthesize wiring behind KI_V5_VERIFY_
 """
 from __future__ import annotations
 
-from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
-
 from app.cortex import graph as cx
 from app.cortex import verify
 from app.cortex.verify import (
@@ -15,6 +13,7 @@ from app.cortex.verify import (
     render_review_note,
     review_rca,
 )
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 
 class _LLM:

--- a/v4/tests/test_version.py
+++ b/v4/tests/test_version.py
@@ -59,10 +59,9 @@ class TestVersionInfoAndLine:
 
 
 def test_healthz_reports_version_identity():
-    from starlette.testclient import TestClient
-
     from app.api.v1.endpoints.health import router
     from fastapi import FastAPI
+    from starlette.testclient import TestClient
 
     app = FastAPI()
     app.include_router(router)

--- a/v4/tests/test_workflow_config_injection.py
+++ b/v4/tests/test_workflow_config_injection.py
@@ -68,9 +68,8 @@ class TestGraphNodeConfigInjection:
 class TestToolConfigInjection:
     def test_run_kubectl_config_param_is_detected(self):
         """LangChain injects the run config only on an exact `RunnableConfig` annotation."""
-        from langchain_core.tools.base import _get_runnable_config_param
-
         from app.tools.kubectl_tool import run_kubectl
+        from langchain_core.tools.base import _get_runnable_config_param
 
         assert _get_runnable_config_param(run_kubectl.func) == "config", (
             "run_kubectl no longer receives the run config — user_role and hitl_bypass "


### PR DESCRIPTION
Fixes #76

## What & why

Runs the single command the issue prescribes — `ruff check v4 --select I001 --fix` (ruff 0.16.2) — clearing all 75 `I001` findings so the ruff pin can eventually be lifted. Only import blocks are reordered; nothing is renamed, added, or removed.

One manual adjustment on top of the autofix: in `packages/kubeintellect-server/app/cortex/models.py`, ruff wrapped the long `langchain_anthropic` import into parenthesized form, which moved the `# type: ignore[import-not-found]` comment off the `from` line and broke the mypy suppression for that optional extra (mypy went from 0 to 1 error). The comment now sits on the `from ... import (` line, keeping both the sorted form and the suppression.

## Verify

```
$ ruff check v4 --select I001 --statistics
(no findings)

$ git diff --stat | tail -1
 60 files changed, 98 insertions(+), 108 deletions(-)
```

(The issue title says 75 files; ruff reports 75 `I001` findings, which land in 60 unique files — some files carry more than one unsorted block.)

## Type of change

- [x] 🧹 Refactor / chore

## Scope

- Version directory touched: v4/
- [x] This change is scoped to a version whose contributions are open (`v4/`, or docs/typos in older versions).

## Checklist

- [ ] New behavior has both a **happy-path** and an **error-path** test (n/a — no behavior change)
- [x] **Every mutating/write operation keeps its dry-run + diff + human-approval (HITL) gate** (safety invariant)
- [x] Secret values are never logged or returned (key names only)
- [x] `uv run pytest` passes locally (server: 995 passed; kq: 312 passed)
- [x] `uv run ruff check .` passes locally
- [x] `uv run mypy src` passes locally (0 errors across 171 files)
- [ ] Docs updated if behavior/CLI/flags changed (n/a)
- [x] Commits are signed off (`git commit -s` — DCO)

## Notes for reviewers

All six `make setup` gates are green locally. Per the issue's scope notes: only `I001` was run (no bare `--fix`), `UP045` untouched, `v1/`–`v3/` untouched, and the `ruff` pin in `v4/pyproject.toml` is unchanged.
