### PR TITLE
test(kube-q): pin terminal env for deterministic Rich output

### DIFF
--- a/v4/packages/kube-q/tests/conftest.py
+++ b/v4/packages/kube-q/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Shared pytest fixtures for kube-q.
+
+Pin terminal rendering env for the whole suite. Rich/console output otherwise
+depends on the developer's COLUMNS, TERM, and NO_COLOR, which makes unrelated
+tests fail on narrow or dumb terminals (see #106).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _pin_terminal_rendering_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COLUMNS", "120")
+    monkeypatch.setenv("TERM", "xterm-256color")
+    monkeypatch.delenv("NO_COLOR", raising=False)


### PR DESCRIPTION
## Summary
- Add an autouse pytest fixture in `v4/packages/kube-q/tests/conftest.py` that pins `COLUMNS=120`, `TERM=xterm-256color`, and clears `NO_COLOR`.
- Keeps assertions intact while making the suite independent of the local terminal.

Closes #106

Made with [Cursor](https://cursor.com)