### PR TITLE
test(kube-q): pin terminal rendering environment

### DIFF
--- a/v4/packages/kube-q/tests/conftest.py
+++ b/v4/packages/kube-q/tests/conftest.py
@@ -1,0 +1,43 @@
+"""Shared pytest configuration for the kube-q CLI suite."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+_PINNED_TERMINAL_ENV = {
+    "COLUMNS": "120",
+    "TERM": "xterm-256color",
+}
+_ORIGINAL_TERMINAL_ENV: dict[str, str | None] = {}
+
+
+def _pin_terminal_environment() -> None:
+    for key, value in _PINNED_TERMINAL_ENV.items():
+        os.environ[key] = value
+    os.environ.pop("NO_COLOR", None)
+
+
+def pytest_configure() -> None:
+    """Pin Rich before test modules create consoles during collection."""
+    for key in (*_PINNED_TERMINAL_ENV, "NO_COLOR"):
+        _ORIGINAL_TERMINAL_ENV[key] = os.environ.get(key)
+    _pin_terminal_environment()
+
+
+def pytest_unconfigure() -> None:
+    """Restore the invoking process environment after the suite."""
+    for key, value in _ORIGINAL_TERMINAL_ENV.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+@pytest.fixture(autouse=True)
+def _stable_terminal_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Keep Rich output deterministic across contributor terminals without weakening assertions.
+    for key, value in _PINNED_TERMINAL_ENV.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.delenv("NO_COLOR", raising=False)


### PR DESCRIPTION
## What & why

Closes #106.

The kube-q suite inherited `COLUMNS`, `TERM`, and `NO_COLOR` from the contributor's shell. That changed Rich table wrapping, terminal-height behavior, and the theme used by the module-level renderer console, so unrelated tests could fail before a contributor changed any code.

This adds one suite-level pytest configuration that:

- pins `COLUMNS=120` and `TERM=xterm-256color` before test-module collection;
- clears `NO_COLOR` before collection so import-time consoles use the normal test theme;
- reapplies the same baseline with an autouse fixture before every test while still allowing individual tests to override it with `monkeypatch`;
- restores the invoking process environment when pytest exits.

No production code or assertion was changed.

## Type of change

- [x] 🐛 Bug fix
- [x] 🧪 Tests

## Scope

- Version directory touched: `v4/packages/kube-q/`
- [x] This change is scoped to a version whose contributions are open.

## Validation

On current `main` (`2c1f6765`), the clean one-variable-at-a-time RED matrix was:

- `COLUMNS=40`: 5 failed, 307 passed
- `COLUMNS=60`: 1 failed, 311 passed
- `COLUMNS=200`: 312 passed
- `TERM=dumb`: 1 failed, 311 passed
- `NO_COLOR=1`: 1 failed, 311 passed

With this commit, all five runs pass: **312/312 each** on Python 3.13.13. The full suite also passes **312/312 on Python 3.12.0** with all three hostile values applied simultaneously (`COLUMNS=40 TERM=dumb NO_COLOR=1`).

`make setup` passes all six locally runnable gates:

- Ruff: clean
- mypy: zero errors across 171 source files
- server suite: 995 passed
- kube-q suite: 312 passed
- file modes: clean
- syntax warnings: clean

## Checklist

- [x] The regression is proven by the unchanged assertions failing before and passing after the environment pin
- [x] No production write, HITL, RBAC, secret, CLI, or documentation behavior changes
- [x] All locally runnable CI gates pass
- [x] Commit is signed off (DCO)

## AI assistance

Substantial AI assistance was used to inspect the Rich/pytest import timing, implement the fixture, and prepare this PR. I reviewed the resulting code and ran every validation result reported above locally.
