### PR TITLE
chore(server,kube-q): modernize datetime.UTC and TimeoutError aliases…

### DIFF
--- a/v4/packages/kube-q/kube_q/cli/config_cmd.py
+++ b/v4/packages/kube-q/kube_q/cli/config_cmd.py
@@ -394,8 +394,8 @@ if __name__ == "__main__":
 
 __all__ = [
     "Config",  # re-exported for type hints in callers
-    "run",
-    "cmd_show",
-    "cmd_set",
     "cmd_reset",
+    "cmd_set",
+    "cmd_show",
+    "run",
 ]

--- a/v4/packages/kubeintellect-server/app/db/flight_recorder.py
+++ b/v4/packages/kubeintellect-server/app/db/flight_recorder.py
@@ -231,7 +231,7 @@ async def _drain() -> None:
                 batch.append(item)
                 while len(batch) < _BATCH_MAX and not _queue.empty():
                     batch.append(_queue.get_nowait())
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 pass
             if batch:
                 await _flush(batch)

--- a/v4/packages/kubeintellect-server/app/digest/builder.py
+++ b/v4/packages/kubeintellect-server/app/digest/builder.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 import time
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 
 from app.utils.logger import get_logger
 
@@ -27,7 +27,7 @@ def _get_pool():
 async def build_digest(hours: float = 24.0) -> dict:
     """Structured digest for the last N hours. Empty sections when quiet."""
     pool = _get_pool()
-    cutoff = datetime.fromtimestamp(time.time() - hours * 3600, tz=timezone.utc)
+    cutoff = datetime.fromtimestamp(time.time() - hours * 3600, tz=UTC)
     digest: dict = {
         "window_hours": hours,
         "generated_at": time.time(),

--- a/v4/packages/kubeintellect-server/app/memory/episodes.py
+++ b/v4/packages/kubeintellect-server/app/memory/episodes.py
@@ -12,7 +12,7 @@ catches, logs, and returns a safe empty value.
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from typing import Any
 
 from app.core.config import settings
@@ -403,4 +403,4 @@ async def backfill_from_rca_outcomes(cluster_id_default: str = "unknown") -> int
 def _ts(value: float | None) -> datetime | None:
     if value is None:
         return None
-    return datetime.fromtimestamp(value, tz=timezone.utc)
+    return datetime.fromtimestamp(value, tz=UTC)

--- a/v4/packages/kubeintellect-server/app/memory/kg.py
+++ b/v4/packages/kubeintellect-server/app/memory/kg.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import json
 import time
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from typing import Any
 
 import asyncpg
@@ -51,7 +51,7 @@ def close_kg() -> None:
 
 def _ts(value: float) -> datetime:
     """Unix float → tz-aware datetime for asyncpg TIMESTAMPTZ params."""
-    return datetime.fromtimestamp(value, tz=timezone.utc)
+    return datetime.fromtimestamp(value, tz=UTC)
 
 
 def _attrs_json(attrs: dict[str, Any] | None) -> str:

--- a/v4/packages/kubeintellect-server/app/memory/prospective.py
+++ b/v4/packages/kubeintellect-server/app/memory/prospective.py
@@ -24,7 +24,7 @@ prospective failure must never break a request or stall the consolidation loop.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from typing import Any
 
 from app.autonomy.ladder import at_least, level_for_namespace
@@ -188,4 +188,4 @@ async def _record_outcome(pool, recheck_id, outcome: str) -> None:
 
 
 def _ts(value: float) -> datetime:
-    return datetime.fromtimestamp(value, tz=timezone.utc)
+    return datetime.fromtimestamp(value, tz=UTC)

--- a/v4/packages/kubeintellect-server/app/streaming/emitter.py
+++ b/v4/packages/kubeintellect-server/app/streaming/emitter.py
@@ -53,10 +53,10 @@ __all__ = [
     "TokenEvent",
     "ToolCallEvent",
     "ToolResultEvent",
-    "prepare_session",
-    "emit",
     "close_session",
+    "emit",
     "get_history",
+    "prepare_session",
     "stream",
 ]
 
@@ -134,7 +134,7 @@ async def stream(session_id: str, heartbeat_interval: float = 15.0):
     while True:
         try:
             item = await asyncio.wait_for(q.get(), timeout=heartbeat_interval)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             yield None   # caller emits ": heartbeat\n\n"
             continue
         if item is _DONE:

--- a/v4/packages/kubeintellect-server/app/tools/aci/__init__.py
+++ b/v4/packages/kubeintellect-server/app/tools/aci/__init__.py
@@ -17,10 +17,10 @@ ACI_READ_VERB_ALLOWLIST = frozenset({"inspect", "search", "logs", "diff_change"}
 ACI_READ_VERBS = [inspect, search, logs, diff_change]
 
 __all__ = [
-    "ACI_READ_VERB_ALLOWLIST",
     "ACI_READ_VERBS",
-    "inspect",
-    "search",
-    "logs",
+    "ACI_READ_VERB_ALLOWLIST",
     "diff_change",
+    "inspect",
+    "logs",
+    "search",
 ]

--- a/v4/packages/kubeintellect-server/app/tools/loki_tool.py
+++ b/v4/packages/kubeintellect-server/app/tools/loki_tool.py
@@ -191,5 +191,5 @@ def _range_query(
 def _fmt_ts(ts_ns: int) -> str:
     """Format a nanosecond timestamp as HH:MM:SS."""
     import datetime
-    dt = datetime.datetime.fromtimestamp(ts_ns / 1e9, tz=datetime.timezone.utc)
+    dt = datetime.datetime.fromtimestamp(ts_ns / 1e9, tz=datetime.UTC)
     return dt.strftime("%H:%M:%S")


### PR DESCRIPTION
…, sort `__all__`

Ruff 0.16 flags `UP017` (`datetime.timezone.utc` → `datetime.UTC`), `UP041` (`asyncio.TimeoutError` → `TimeoutError`), and `RUF022` (unsorted `__all__`). These are no-ops on Python ≥3.12.

Applied the targeted autofix and removed the four now-unused `datetime.timezone` imports. No behavior was changed.

`UP017`, `UP041`, and `RUF022` now report zero findings.

Fixes #79

## What & why

Modernize the three Ruff 0.16 rule families without changing runtime behavior or touching unrelated Ruff rules.

The deliberate `# noqa: UP017` in `kube_q/cli/store.py` was left unchanged.

## Type of change

* [ ] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 📖 Docs
* [x] 🧹 Refactor / chore
* [ ] ⚡ Performance
* [ ] 🧪 Tests

## Scope

* Version directory touched: `v4/`
* [x] This change is scoped to a version whose contributions are open (`v4/`, or docs/typos in older versions).

## Verification

* [x] `uv run pytest` passes locally

  * kube-q: **297 passed**
  * server: **986 passed, 2 warnings**
* [x] Targeted Ruff rules pass:

  * `uv run ruff check . --select UP017,UP041,RUF022 --statistics`
  * **0 findings**
* [x] Commits are signed off (`git commit -s` — DCO)

## Checklist

* [ ] New behavior has both a **happy-path** and an **error-path** test
* [x] **Every mutating/write operation keeps its dry-run + diff + human-approval (HITL) gate** (safety invariant) — no mutating operations were changed
* [x] Secret values are never logged or returned (key names only) — no secret-handling code was changed
* [x] `uv run pytest` passes locally
* [x] Targeted `uv run ruff check . --select UP017,UP041,RUF022` passes locally
* [ ] `uv run mypy src` passes locally — not applicable; this repository has no `src/` directory
* [x] Docs updated if behavior/CLI/flags changed — no behavior, CLI, or flags changed
* [x] Commits are signed off (`git commit -s` — DCO)

## Notes for reviewers

This is intentionally a narrow lint modernization.

The changes are limited to:

* `datetime.timezone.utc` → `datetime.UTC`
* `asyncio.TimeoutError` → `TimeoutError`
* sorting `__all__` definitions
* removing the four imports made unused by the `UP017` autofix

The existing Ruff pin was not changed, and the deliberate `# noqa: UP017` in `kube_q/cli/store.py` remains untouched.

Final diff: **9 files changed, 19 insertions(+), 19 deletions(-)**.
