### PR TITLE
fix(packaging): update kube-q Homebrew formula

### DIFF
--- a/v4/packages/kube-q/Formula/kube-q.rb
+++ b/v4/packages/kube-q/Formula/kube-q.rb
@@ -2,31 +2,107 @@ class KubeQ < Formula
   include Language::Python::Virtualenv
 
   desc "Interactive terminal CLI for chatting with your Kubernetes cluster via an AI backend"
-  homepage "https://github.com/MSKazemi/kube_q"
-  url "https://files.pythonhosted.org/packages/source/k/kube-q/kube_q-1.0.0.tar.gz"
-  sha256 "0ecce3a15800343c3cbcd9490ce695e923b4390c0808629fcaec5ea03a9c967d"
-  license "MIT"
+  homepage "https://github.com/MSKazemi/kubeintellect"
+  url "https://files.pythonhosted.org/packages/92/85/5d0af5d4fcff49447325ffd338c2ef5e386d99b6a106b570f8e97bb66d60/kube_q-1.5.0.tar.gz"
+  sha256 "738363d6f3c5c1f97c561924ab232e2cfc0ca6cacb5c9bdb18ab756aa1b1cfc1"
+  license "AGPL-3.0-or-later"
 
+  depends_on "certifi" => :no_linkage
+  depends_on "libyaml"
+  depends_on "maturin" => :build
   depends_on "python@3.12"
+  depends_on "rust" => :build
+
+  pypi_packages exclude_packages: "certifi"
+
+  resource "anyio" do
+    url "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz"
+    sha256 "cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f"
+  end
+
+  resource "annotated-types" do
+    url "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz"
+    sha256 "13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7"
+  end
+
+  resource "h11" do
+    url "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz"
+    sha256 "4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"
+  end
+
+  resource "httpcore" do
+    url "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz"
+    sha256 "6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"
+  end
 
   resource "httpx" do
-    url "https://files.pythonhosted.org/packages/source/h/httpx/httpx-0.28.1.tar.gz"
+    url "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz"
     sha256 "75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"
   end
 
-  resource "rich" do
-    url "https://files.pythonhosted.org/packages/source/r/rich/rich-14.3.3.tar.gz"
-    sha256 "5a5c2a4d5e8bbf946abbc1c86e8a69a7e0fb70d8e8c41e6aeeb3d08b7d6c4c3"
+  resource "idna" do
+    url "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz"
+    sha256 "ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"
   end
 
-  resource "prompt_toolkit" do
-    url "https://files.pythonhosted.org/packages/source/p/prompt_toolkit/prompt_toolkit-3.0.51.tar.gz"
-    sha256 "ee2b1d8a1de5c6f0a9e0b28c5c7b0e48dc3bedd0c9cbf7c62d79ad27012a41c"
+  resource "ki-protocol" do
+    url "https://files.pythonhosted.org/packages/88/61/0c7927630aa8300d098a7614fa145395aa19a66b32358a9c345a58aa31a7/ki_protocol-1.0.0.tar.gz"
+    sha256 "d9034acf8a3997d77fe476da80435e47b478a6ebb09d535e720f96016e456737"
+  end
+
+  resource "markdown-it-py" do
+    url "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz"
+    sha256 "04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49"
+  end
+
+  resource "mdurl" do
+    url "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
+    sha256 "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"
+  end
+
+  resource "prompt-toolkit" do
+    url "https://files.pythonhosted.org/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz"
+    sha256 "9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6"
+  end
+
+  resource "pydantic" do
+    url "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz"
+    sha256 "c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6"
+  end
+
+  resource "pydantic-core" do
+    url "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz"
+    sha256 "62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1"
   end
 
   resource "pygments" do
-    url "https://files.pythonhosted.org/packages/source/p/pygments/pygments-2.18.0.tar.gz"
-    sha256 "786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199"
+    url "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz"
+    sha256 "6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"
+  end
+
+  resource "pyyaml" do
+    url "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz"
+    sha256 "d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"
+  end
+
+  resource "rich" do
+    url "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz"
+    sha256 "edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"
+  end
+
+  resource "typing-extensions" do
+    url "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz"
+    sha256 "dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5"
+  end
+
+  resource "typing-inspection" do
+    url "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz"
+    sha256 "ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"
+  end
+
+  resource "wcwidth" do
+    url "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz"
+    sha256 "91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda"
   end
 
   def install


### PR DESCRIPTION
## What & why

Closes #56.

The formula still pointed at the removed `kube-q` 1.0.0 source archive, declared MIT even though the current package is AGPL, and shipped only part of the runtime dependency set. This updates the formula to the published `kube-q` 1.5.0 release, uses the canonical repository homepage and license, and declares the complete runtime resource tree required by Homebrew's dependency-free pip installation. `certifi` is provided by Homebrew and is explicitly excluded from the PyPI resources.

## Type of change

- [x] 🐛 Bug fix

## Scope

- Version directory touched: `v4/`
- [x] This change is scoped to a version whose contributions are open (`v4/`, or docs/typos in older versions).

## Validation

- `git diff --check`
- Downloaded the main sdist and all 18 declared resources, verified every SHA-256 against the downloaded bytes, and checked the PyPI metadata for the declared URLs and Homebrew's 24-hour release cooldown.
- Resolved the active recursive runtime dependency graph for Python 3.12: 19 packages are covered by the formula resources or the Homebrew `certifi` dependency.
- `python -m pip install --dry-run --ignore-installed --report - kube-q==1.5.0` — 20 packages resolved.
- Reviewed the formula against the current Homebrew `virtualenv_install_with_resources`, `std_pip_args`, `update-python-resources`, and official Python formula patterns.

Homebrew itself, Ruby, and WSL are not installed in the development environment, so `brew audit --strict` and `brew install --build-from-source` could not be run locally. I am reporting that limitation explicitly rather than treating the static and PyPI checks as an install test.

## Notes for reviewers

`pydantic-core` is built from its sdist and therefore includes the `maturin` and Rust build dependencies. PyYAML's source build uses the Homebrew `libyaml` dependency.

## AI assistance

Substantial AI assistance was used to inspect the published package metadata. I reviewed the resulting diff and ran the validation listed above; the Homebrew-native checks remain for CI or a maintainer environment because Homebrew is unavailable locally.