### PR TITLE
fix(memory): make recall similarity floor configurable

### DIFF
--- a/v4/packages/kubeintellect-server/app/core/config.py
+++ b/v4/packages/kubeintellect-server/app/core/config.py
@@ -210,6 +210,9 @@ class Settings(BaseSettings):
     # baseline single-channel trgm recall. Additive; no schema change required
     # (ts_rank is computed inline; a stored tsvector + GIN index is the P0 speedup).
     MEMORY_HYBRID_RETRIEVAL: bool = False
+    # Minimum pg_trgm similarity used by the baseline recall and summary channels.
+    # Keep this configurable for deployments with different memory vocabularies.
+    MEMORY_RECALL_SIMILARITY_FLOOR: float = Field(default=0.02, ge=0.0, le=1.0)
     # Memory V5 P2 (ADR-013): bi-temporal KG. When on, edge writes stamp event-time
     # valid_from (from the observation) and supersede via retract (retracted_at) instead
     # of only closing (valid_to); point-in-time `as_of(valid_t, tx_t)` queries become

--- a/v4/packages/kubeintellect-server/app/memory/episodes.py
+++ b/v4/packages/kubeintellect-server/app/memory/episodes.py
@@ -25,8 +25,6 @@ _pool = None  # asyncpg.Pool — owned by app.memory.service
 
 # Reciprocal Rank Fusion constant (Cormack et al. 2009). Memory V5 ADR-014 / P1.
 _RRF_K = 60
-# Baseline trgm noise floor — unrelated episodes below this don't help the prompt.
-_TRGM_FLOOR = 0.02
 
 # ── Memory V5 P6 (ADR-017): importance / surprise ────────────────────────────
 # Importance derives from incident severity: a regression a fix caused is the most
@@ -312,7 +310,8 @@ async def recall_episodes(
         if hybrid:
             rows = await _pool.fetch(
                 _SQL_RECALL_HYBRID_IMP if importance else _SQL_RECALL_HYBRID,
-                query_text[:500], cluster_id, k, _RRF_K, _TRGM_FLOOR,
+                query_text[:500], cluster_id, k, _RRF_K,
+                settings.MEMORY_RECALL_SIMILARITY_FLOOR,
             )
         else:
             rows = await _pool.fetch(
@@ -338,7 +337,11 @@ async def recall_episodes(
         # Baseline path applies the trgm noise floor here; the hybrid SQL already
         # filtered to channel-matched rows (a lex-only match has sim ≤ floor but
         # is still relevant), so it must NOT re-apply the trgm floor.
-        if not hybrid and row["sim"] is not None and row["sim"] <= _TRGM_FLOOR:
+        if (
+            not hybrid
+            and row["sim"] is not None
+            and row["sim"] <= settings.MEMORY_RECALL_SIMILARITY_FLOOR
+        ):
             continue
         out.append(dict(row))
     return out

--- a/v4/packages/kubeintellect-server/app/memory/summaries.py
+++ b/v4/packages/kubeintellect-server/app/memory/summaries.py
@@ -28,9 +28,6 @@ from app.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-# Unrelated summaries below this trgm score don't help a theme query.
-_SUMMARY_FLOOR = 0.02
-
 # Per-cluster KG edge count — the change-rate watermark (R7.1).
 _SQL_KG_WATERMARK = "SELECT cluster_id, count(*) AS n FROM kg_edges GROUP BY cluster_id"
 
@@ -150,7 +147,7 @@ async def recall_theme_summaries(
         return []
     return [
         dict(r) for r in rows
-        if r["sim"] is None or r["sim"] > _SUMMARY_FLOOR
+        if r["sim"] is None or r["sim"] > settings.MEMORY_RECALL_SIMILARITY_FLOOR
     ]
 
 

--- a/v4/tests/test_memory_hierarchy.py
+++ b/v4/tests/test_memory_hierarchy.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 import time
 
-from app.memory import episodes
+from app.core.config import settings
+from app.memory import episodes, service, summaries
 from app.memory.consolidation import _playbooks_from_key
 
 
@@ -35,6 +36,9 @@ class FakePool:
 
 
 class TestEpisodes:
+    def test_recall_similarity_floor_defaults_to_point_zero_two(self):
+        assert settings.MEMORY_RECALL_SIMILARITY_FLOOR == 0.02
+
     async def test_write_returns_id(self):
         pool = FakePool(row={"id": "ep-uuid-1"})
         episodes.init_episodes(pool)
@@ -85,6 +89,31 @@ class TestEpisodes:
         try:
             out = await episodes.recall_episodes("crashloop payments", "c1")
             assert len(out) == 1 and out[0]["id"] == "1"
+        finally:
+            episodes.close_episodes()
+
+    async def test_recall_uses_configured_similarity_floor(self, mocker):
+        mocker.patch.object(episodes.settings, "MEMORY_RECALL_SIMILARITY_FLOOR", 0.0)
+        pool = FakePool(
+            rows=[
+                {
+                    "id": "low-sim",
+                    "summary": "rare incident",
+                    "root_cause": None,
+                    "outcome": None,
+                    "verified": None,
+                    "confidence": None,
+                    "playbooks": [],
+                    "namespace": None,
+                    "started_at": None,
+                    "sim": 0.01,
+                }
+            ]
+        )
+        episodes.init_episodes(pool)
+        try:
+            out = await episodes.recall_episodes("rare incident", "c1")
+            assert [row["id"] for row in out] == ["low-sim"]
         finally:
             episodes.close_episodes()
 
@@ -173,6 +202,28 @@ class TestConsolidation:
 
         mocker.patch.object(service, "_pool", None)
         assert await consolidation.run_consolidation_once() == {}
+
+
+class TestSummaryRecall:
+    async def test_recall_uses_configured_similarity_floor(self, mocker):
+        mocker.patch.object(summaries.settings, "MEMORY_RECALL_SIMILARITY_FLOOR", 0.0)
+        pool = FakePool(
+            rows=[
+                {
+                    "theme_key": "rare incident",
+                    "summary": "one episode",
+                    "member_count": 1,
+                    "verified_count": 0,
+                    "last_episode_at": None,
+                    "sim": 0.01,
+                }
+            ]
+        )
+        mocker.patch.object(service, "_pool", pool)
+
+        out = await summaries.recall_theme_summaries("rare incident", "c1")
+
+        assert [row["theme_key"] for row in out] == ["rare incident"]
 
 
 class TestInjectionLatencyGate:


### PR DESCRIPTION
## What & why

Closes #14

The trigram similarity floor used by episodic recall and theme-summary recall was hard-coded independently in both modules. This change adds a validated `MEMORY_RECALL_SIMILARITY_FLOOR` setting with the existing `0.02` default and uses it on both recall paths.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ⚡ Performance
- [ ] 🔒 Security
- [ ] 📝 Documentation
- [ ] 🧹 Refactor / chore

## Scope

- Version directory touched: `v4/`
- [x] No behavior change outside the selected version
- [x] No secrets, API keys, or credentials added
- [x] Existing default behavior is preserved

## Checks

- [x] `ruff check packages/kubeintellect-server/app/ packages/ki-protocol/`
- [x] `mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube-q/kube_q`
- [x] Server suite: `1011 passed, 1 warning`
- [x] Kube-q suite: `312 passed`
- [x] `make check-modes`
- [x] `make check-syntax`
- [x] Commit includes DCO sign-off

## Notes for reviewers

The hybrid recall SQL now receives the configured threshold, while baseline episodic and summary post-filters read the same setting. The default remains `0.02`.

AI assistance: I used AI assistance to help inspect the existing recall paths and draft the focused tests and patch. I reviewed the diff and validation output before submitting.
