### PR TITLE
fix: restore v4/.env.example (#115)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@
 # ── Secrets ──────────────────────────────────────────────────────────────────
 .env
 .env.*
+# Allow the example template to be versioned — it contains only placeholders.
+# Must come *after* .env.* so the negation takes effect (git check-ignore is last-match-wins).
+!.env.example
+!**/.env.example
 *.local
 *.pem
 *.key

--- a/v4/.env.example
+++ b/v4/.env.example
@@ -1,0 +1,244 @@
+# KubeIntellect — Runtime Configuration
+#
+# Usage:
+#   cp .env.example .env
+#   # Edit .env — fill in at minimum: LLM key + POSTGRES_PASSWORD + one ADMIN key
+#   docker compose up -d
+#
+# This file is read by Docker Compose only.
+# Kubernetes (Helm) deployments use a ConfigMap + Secret — not this file.
+#
+# NEVER commit .env to git — it is already listed in .gitignore.
+# Generate secure keys with: openssl rand -hex 20
+#
+# Full variable reference: https://mskazemi.github.io/kubeintellect/configuration/
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# LLM PROVIDER  (required — pick one)
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Which LLM backend to use. Must be exactly: azure  or  openai
+
+LLM_PROVIDER=azure
+
+
+# ── Option A: Azure OpenAI ────────────────────────────────────────────────────
+#
+# Required when LLM_PROVIDER=azure.
+# Find these in Azure Portal → your OpenAI resource → Keys and Endpoint.
+
+AZURE_OPENAI_API_KEY=
+AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/
+
+# Deployment names — must match names in Azure AI Foundry → Deployments.
+AZURE_COORDINATOR_DEPLOYMENT=gpt-4o
+AZURE_SUBAGENT_DEPLOYMENT=gpt-4o-mini
+
+# API version — update when Microsoft releases a newer GA version.
+AZURE_OPENAI_API_VERSION=2024-02-01
+
+
+# ── Option B: OpenAI (direct) ─────────────────────────────────────────────────
+#
+# Required when LLM_PROVIDER=openai.
+# Get your key at https://platform.openai.com/api-keys
+
+# OPENAI_API_KEY=sk-...
+# OPENAI_COORDINATOR_MODEL=gpt-4o
+# OPENAI_SUBAGENT_MODEL=gpt-4o-mini
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# DATABASE  (required)
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# KubeIntellect uses PostgreSQL to persist conversation memory and the audit log.
+# Docker Compose starts a postgres container automatically — you only need to set
+# the password. Everything else can stay at its default.
+
+
+# ── Option A: Docker Compose postgres (default) ───────────────────────────────
+#
+# These values are shared between the kubeintellect container and the postgres
+# container started by docker-compose.yaml. Change POSTGRES_PASSWORD to something
+# strong — it protects all stored conversation data.
+
+POSTGRES_PASSWORD=changeme          # REQUIRED — use a strong password
+POSTGRES_HOST=postgres              # docker-compose service name — do not change
+POSTGRES_PORT=5432
+POSTGRES_DB=kubeintellect
+POSTGRES_USER=kubeintellect
+POSTGRES_POOL_MIN_CONN=1
+POSTGRES_POOL_MAX_CONN=10
+
+
+# ── Option B: External / managed database ─────────────────────────────────────
+#
+# Overrides all POSTGRES_* vars above. Use this for a cloud-managed database
+# (AWS RDS, Azure Database for PostgreSQL, Google Cloud SQL, etc.).
+# Format: postgresql://user:password@host:5432/dbname
+# Add ?sslmode=require for databases that enforce TLS.
+
+# DATABASE_URL=postgresql://user:password@host:5432/dbname
+
+
+# ── Option C: SQLite (pip / no-Docker only) ───────────────────────────────────
+#
+# Only for local pip-based installs without Docker.
+# Not supported in Docker Compose or Kubernetes deployments.
+
+# USE_SQLITE=true
+# SQLITE_PATH=~/.kubeintellect/kubeintellect.db
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# AUTHENTICATION  (strongly recommended)
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# API key-based auth with three permission tiers.
+# Leave all three empty to run in open-access mode (safe only on localhost).
+#
+# Role summary:
+#   admin    — all operations; destructive commands (delete, drain, patch, scale,
+#              apply, exec…) require human approval before running (HITL-gated)
+#   operator — same as admin but high-risk ops (delete, drain, replace, taint)
+#              are blocked entirely, not just gated
+#   readonly — read-only commands (get, describe, logs, top, events) only;
+#              all writes rejected immediately
+#
+# Each value is a comma-separated list of bearer tokens.
+# Generate a secure key: openssl rand -hex 20
+# Client sends: Authorization: Bearer <key>
+# kube-q CLI:   KUBE_Q_API_KEY=<key> kq
+
+KUBEINTELLECT_ADMIN_KEYS=           # e.g. ki-admin-a1b2c3d4e5f6...
+KUBEINTELLECT_OPERATOR_KEYS=        # e.g. ki-op-a1b2c3d4e5f6...
+KUBEINTELLECT_READONLY_KEYS=        # e.g. ki-ro-a1b2c3d4e5f6...
+
+# ── Demo key backend (optional) ───────────────────────────────────────────────
+#
+# AUTH_BACKEND=hmac enables self-serve demo keys signed with DEMO_KEY_HMAC_SECRET.
+# Users get a personal ki-ro-* key instantly from kubeintellect.com/demo —
+# no server restart needed when new keys are issued.
+# Rotate DEMO_KEY_HMAC_SECRET to invalidate all outstanding demo keys immediately.
+#
+# Leave AUTH_BACKEND=static (default) for standard static-key auth.
+# Generate a secret: openssl rand -hex 32
+
+# AUTH_BACKEND=hmac
+# DEMO_KEY_HMAC_SECRET=
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# KUBERNETES ACCESS
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# How the container finds and talks to your Kubernetes cluster.
+#
+# Docker Compose: the kubeconfig file is mounted read-only from the host into
+#   the container at /home/app/.kube/config. The KUBECONFIG env var on your
+#   host controls which file is mounted (default: ~/.kube/config).
+#   To use a different kubeconfig: KUBECONFIG=/path/to/other docker compose up -d
+#
+# Kubernetes (Helm): KUBECONFIG_PATH is set to "" in the ConfigMap, which tells
+#   kubectl to use the pod's ServiceAccount token automatically. No file needed.
+
+KUBECONFIG_PATH=~/.kube/config      # resolves to /home/app/.kube/config in container
+
+# Timeout in seconds for read operations (get, describe, logs…)
+KUBECTL_TIMEOUT_SECONDS=30
+
+# Timeout in seconds for write operations (apply, delete, scale, exec…)
+# These are always HITL-gated before running — the timeout only applies
+# to the actual kubectl execution after the user approves.
+KUBECTL_DESTRUCTIVE_TIMEOUT_SECONDS=300
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# OBSERVABILITY  (optional)
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# URLs of Prometheus and Loki running in (or accessible from) your cluster.
+# KubeIntellect uses these to answer metric and log questions through the agent.
+#
+# Leave empty to skip — kubectl-based queries always work without them.
+# The agent returns a "data source not configured" message if asked for
+# metrics or logs when these are empty, rather than crashing.
+
+
+# ── Prometheus ────────────────────────────────────────────────────────────────
+# Enables PromQL metric queries: "show CPU usage for the payment service"
+
+# Docker Compose (--profile monitoring):
+# PROMETHEUS_URL=http://localhost:9090
+
+# In-cluster (Kind / Helm after make monitoring-install):
+# PROMETHEUS_URL=http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+
+# External (company Prometheus):
+PROMETHEUS_URL=
+
+
+# ── Loki ──────────────────────────────────────────────────────────────────────
+# Enables LogQL queries: "show error logs for the auth service in the last hour"
+
+# Docker Compose (--profile monitoring):
+# LOKI_URL=http://localhost:3100
+
+# In-cluster (Kind / Helm after make monitoring-install):
+# LOKI_URL=http://loki.monitoring.svc.cluster.local:3100
+
+# External (company Loki):
+LOKI_URL=
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# LANGFUSE — LLM TRACING  (optional)
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Self-hosted LLM observability: inspect every prompt, token count, latency,
+# and model response for every agent call.
+#
+# To start a local Langfuse instance:
+#   docker compose --profile tracing up -d
+#   Visit http://localhost:3001 → create account → Settings → API Keys
+#
+# To use a cloud Langfuse account: https://cloud.langfuse.com
+
+LANGFUSE_ENABLED=false
+
+# Address of the Langfuse server this instance sends traces to.
+# Docker Compose (--profile tracing):
+LANGFUSE_HOST=http://localhost:3001
+# In-cluster (Helm after make langfuse-install):
+# LANGFUSE_HOST=http://langfuse-web.monitoring.svc.cluster.local:3000
+
+# API keys — copy from Langfuse → Settings → API Keys after creating a project.
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
+
+# Langfuse's own internal database (only used when running --profile tracing).
+# These are Langfuse's credentials, not KubeIntellect's.
+LANGFUSE_DB_PASSWORD=langfuse-local
+LANGFUSE_NEXTAUTH_SECRET=changeme-local-secret-32chars!!
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# APPLICATION SETTINGS
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Log level: DEBUG | INFO | WARNING | ERROR
+LOG_LEVEL=INFO
+
+# Log format: text (human-readable) | json (structured, for log aggregators)
+LOG_FORMAT=text
+
+# FastAPI debug mode — enables auto-reload and detailed error pages.
+# Keep false in production.
+DEBUG=false
+
+# CORS allowed origins — comma-separated list of URLs allowed to call the API
+# from a browser. Only relevant if you build a web frontend.
+# For local kube-q CLI use, the default is fine.
+ALLOWED_ORIGINS=http://localhost:3080


### PR DESCRIPTION

<!--
Thanks for contributing to KubeIntellect! 💙
Please fill this out so reviewers can move fast. See CONTRIBUTING.md for the full guide.
-->

## What & why

Closes #115

Allow .env.example via .gitignore negation and restore v4 template from 96ae100^ (244 lines, placeholders only).

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📖 Docs
- [ ] 🧹 Refactor / chore
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## Scope

- Version directory touched: `v4/`
- [x] This change is scoped to a version whose contributions are open (`v4/`, or docs/typos in older versions).

## Checklist

- [ ] New behavior has both a **happy-path** and an **error-path** test
- [ ] **Every mutating/write operation keeps its dry-run + diff + human-approval (HITL) gate** (safety invariant)
- [x] Secret values are never logged or returned (key names only)
- [x] `uv run pytest` passes locally
- [x] `uv run ruff check .` passes locally
- [ ] `uv run mypy src` passes locally
- [ ] Docs updated if behavior/CLI/flags changed
<!-- Nothing to sign. No CLA, no DCO sign-off, no `git commit -s` — see LICENSING.md. -->

## Notes for reviewers

No real secrets — `v4/.env.example` is placeholder-only (`POSTGRES_PASSWORD=changeme`, `AZURE_OPENAI_API_KEY=` empty). `.gitignore` now allows `!.env.example` / `!**/.env.example` after `.env.*`.