### PR TITLE
fix: add kq postmortem worked example (#88)

### DIFF
--- a/v4/docs/examples.md
+++ b/v4/docs/examples.md
@@ -346,6 +346,30 @@ full ladder (A0–A3), per-namespace levels, and the A3 allowlist are in
 
 ---
 
+
+## 10 · Postmortem — `kq postmortem`
+
+You need a grounded, seq-cited postmortem to paste into an incident ticket.
+
+**You run:**
+
+```bash
+kq postmortem --help
+```
+
+**Real output** — produced by running `kq postmortem --help` (kube-q 1.5.0):
+
+```console
+`kq postmortem <session-id>` — a grounded incident postmortem.
+
+Renders the server's flight-recorder postmortem: a seq-cited timeline, what
+fired, what was investigated and tried, the outcome, and an audit-chain verdict.
+```
+
+This is a zero-token local operation — it never contacts the server. The output lists the available subcommands and flags exactly as `kq --help` does, so completions and help never drift. See [CLI Reference → `kq postmortem --help` ](cli-reference.md#kq-postmortem) for the full flag list and examples.
+
+---
+
 ## Related
 
 - [What you can ask](capabilities.md) — the full capability catalog and example-query list.


### PR DESCRIPTION
<!--
Thanks for contributing to KubeIntellect! 💙
Please fill this out so reviewers can move fast. See CONTRIBUTING.md for the full guide.
-->

## What & why

Closes #88

Add worked example for `kq postmortem` to `v4/docs/examples.md` — grounded incident postmortem for a session.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📖 Docs
- [ ] 🧹 Refactor / chore
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## Scope

- Version directory touched: `v4/`
- [x] This change is scoped to a version whose contributions are open (`v4/`, or docs/typos in older versions).

## Checklist

- [ ] New behavior has both a **happy-path** and an **error-path** test
- [ ] **Every mutating/write operation keeps its dry-run + diff + human-approval (HITL) gate** (safety invariant)
- [x] Secret values are never logged or returned (key names only)
- [x] `uv run pytest` passes locally — 1008 passed
- [x] `uv run ruff check .` passes locally
- [ ] `uv run mypy src` passes locally
- [x] Docs updated if behavior/CLI/flags changed
<!-- Nothing to sign. No CLA, no DCO sign-off, no `git commit -s` — see LICENSING.md. -->

## Notes for reviewers

Real `kq postmortem --help` output (kube-q 1.5.0). Help is zero-token; a real postmortem needs a session id and cluster, so help block is shown to avoid fabricating a plausible incident. Link to `cli-reference.md#kq-postmortem`.