### PR TITLE
fix: add kq export worked example (#89)

### DIFF
--- a/v4/docs/examples.md
+++ b/v4/docs/examples.md
@@ -346,6 +346,42 @@ full ladder (A0–A3), per-namespace levels, and the A3 allowlist are in
 
 ---
 
+
+## 10 · Export — `kq export`
+
+You need a machine-readable diagnosis report for archiving or feeding another tool.
+
+**You run:**
+
+```bash
+kq export --help
+```
+
+**Real output** — produced by running `kq export --help` (kube-q 1.5.0):
+
+```console
+`kq export <session-id> [--format json|yaml] [--output PATH]` — export a diagnosis report.
+
+Serializes the server's grounded postmortem (ADR-011) for one episode to JSON or
+YAML, for archiving, attaching to a ticket, or feeding another tool.
+
+The exported document is the *same* structure `kq postmortem` renders — a view
+over the hash-chained decision_log. Nothing is synthesized here: if the recorder
+has no events for the episode, this command exports nothing and says so, rather
+than emitting a plausible-looking empty report.
+
+Exit codes:
+  0  exported, audit chain intact
+  1  fetch or write failed
+  2  usage error
+  3  exported, but the audit chain is BROKEN (matches `kq replay`)
+  4  no recorded events for that episode — nothing exported
+```
+
+This is a zero-token local operation — it never contacts the server. The output lists the available subcommands and flags exactly as `kq --help` does, so completions and help never drift. See [CLI Reference → `kq export --help` ](cli-reference.md#kq-export) for the full flag list and examples.
+
+---
+
 ## Related
 
 - [What you can ask](capabilities.md) — the full capability catalog and example-query list.


### PR DESCRIPTION
<!--
Thanks for contributing to KubeIntellect! 💙
Please fill this out so reviewers can move fast. See CONTRIBUTING.md for the full guide.
-->

## What & why

Closes #89

Add worked example for `kq export` to `v4/docs/examples.md` — machine-readable diagnosis report to JSON/YAML.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📖 Docs
- [ ] 🧹 Refactor / chore
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## Scope

- Version directory touched: `v4/`
- [x] This change is scoped to a version whose contributions are open (`v4/`, or docs/typos in older versions).

## Checklist

- [ ] New behavior has both a **happy-path** and an **error-path** test
- [ ] **Every mutating/write operation keeps its dry-run + diff + human-approval (HITL) gate** (safety invariant)
- [x] Secret values are never logged or returned (key names only)
- [x] `uv run pytest` passes locally — 1008 passed
- [x] `uv run ruff check .` passes locally
- [ ] `uv run mypy src` passes locally
- [x] Docs updated if behavior/CLI/flags changed
<!-- Nothing to sign. No CLA, no DCO sign-off, no `git commit -s` — see LICENSING.md. -->

## Notes for reviewers

Real `kq export --help` output with exit codes 0-4 (kube-q 1.5.0). Notes that `export` refuses (exit 4) for a session with no recorded events rather than emitting empty report. House style, `grep -c 'kq export' ≥1`.