### PR TITLE
fix: add kq detector worked example (#90)

### DIFF
--- a/v4/docs/examples.md
+++ b/v4/docs/examples.md
@@ -346,6 +346,36 @@ full ladder (A0–A3), per-namespace levels, and the A3 allowlist are in
 
 ---
 
+
+## 10 · Detector — `kq detector`
+
+You want to teach KubeIntellect a new failure pattern in plain English.
+
+**You run:**
+
+```bash
+kq detector --help
+```
+
+**Real output** — produced by running `kq detector --help` (kube-q 1.5.0):
+
+```console
+`kq detector` — teach the operator a new failure pattern in plain English (ADR-012).
+
+  kq detector new "<plain-English failure description>"   compile + stage as shadow
+  kq detector list [--status shadow|active|demoted]        the candidate queue
+  kq detector shadow <name>                                what a shadow detector fired
+  kq detector promote <name>                               shadow -> active (it can now act)
+  kq detector reject <name>                                stop it firing
+
+New detectors enter SHADOW mode: they observe and accrue precision but never act
+until you promote them.
+```
+
+This is a zero-token local operation — it never contacts the server. The output lists the available subcommands and flags exactly as `kq --help` does, so completions and help never drift. See [CLI Reference → `kq detector --help` ](cli-reference.md#kq-detector-newlistpromote) for the full flag list and examples.
+
+---
+
 ## Related
 
 - [What you can ask](capabilities.md) — the full capability catalog and example-query list.


### PR DESCRIPTION
<!--
Thanks for contributing to KubeIntellect! 💙
Please fill this out so reviewers can move fast. See CONTRIBUTING.md for the full guide.
-->

## What & why

Closes #90

Add worked example for `kq detector` to `v4/docs/examples.md` — author/list/promote natural-language detectors.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📖 Docs
- [ ] 🧹 Refactor / chore
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## Scope

- Version directory touched: `v4/`
- [x] This change is scoped to a version whose contributions are open (`v4/`, or docs/typos in older versions).

## Checklist

- [ ] New behavior has both a **happy-path** and an **error-path** test
- [ ] **Every mutating/write operation keeps its dry-run + diff + human-approval (HITL) gate** (safety invariant)
- [x] Secret values are never logged or returned (key names only)
- [x] `uv run pytest` passes locally — 1008 passed
- [x] `uv run ruff check .` passes locally
- [ ] `uv run mypy src` passes locally
- [x] Docs updated if behavior/CLI/flags changed
<!-- Nothing to sign. No CLA, no DCO sign-off, no `git commit -s` — see LICENSING.md. -->

## Notes for reviewers

Real `kq detector --help` output (shadow/active/demoted lifecycle, ADR-012). Zero-token help, link to `cli-reference.md#kq-detector`.