### PR TITLE
fix: add kq preference worked example (#91)

### DIFF
--- a/v4/docs/examples.md
+++ b/v4/docs/examples.md
@@ -346,6 +346,40 @@ full ladder (A0–A3), per-namespace levels, and the A3 allowlist are in
 
 ---
 
+
+## 10 · Preference — `kq preference`
+
+You want the agent to remember your preferences across sessions.
+
+**You run:**
+
+```bash
+kq preference --help
+```
+
+**Real output** — produced by running `kq preference --help` (kube-q 1.5.0):
+
+```console
+`kq preference` — view and manage the agent's memory of your preferences.
+
+KubeIntellect remembers how you like to operate (explicit + behaviour-inferred)
+and recalls it across sessions. This command manages the explicit ones.
+
+Usage:
+  kq preference list [--user U]
+  kq preference set <key> <value> [--user U]
+  kq preference forget <key> [--user U]
+
+Examples:
+  kq preference set default_namespace payments
+  kq preference set remediation dry-run-first
+  kq preference list
+```
+
+This is a zero-token local operation — it never contacts the server. The output lists the available subcommands and flags exactly as `kq --help` does, so completions and help never drift. See [CLI Reference → `kq preference --help` ](cli-reference.md#kq-preference-listsetforget) for the full flag list and examples.
+
+---
+
 ## Related
 
 - [What you can ask](capabilities.md) — the full capability catalog and example-query list.


### PR DESCRIPTION
<!--
Thanks for contributing to KubeIntellect! 💙
Please fill this out so reviewers can move fast. See CONTRIBUTING.md for the full guide.
-->

## What & why

Closes #91

Add worked example for `kq preference` to `v4/docs/examples.md` — view/set remembered user preferences.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📖 Docs
- [ ] 🧹 Refactor / chore
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## Scope

- Version directory touched: `v4/`
- [x] This change is scoped to a version whose contributions are open (`v4/`, or docs/typos in older versions).

## Checklist

- [ ] New behavior has both a **happy-path** and an **error-path** test
- [ ] **Every mutating/write operation keeps its dry-run + diff + human-approval (HITL) gate** (safety invariant)
- [x] Secret values are never logged or returned (key names only)
- [x] `uv run pytest` passes locally — 1008 passed
- [x] `uv run ruff check .` passes locally
- [ ] `uv run mypy src` passes locally
- [x] Docs updated if behavior/CLI/flags changed
<!-- Nothing to sign. No CLA, no DCO sign-off, no `git commit -s` — see LICENSING.md. -->

## Notes for reviewers

Real `kq preference --help` with `list/set/forget` and examples (`default_namespace payments`, `remediation dry-run-first`). House style, `grep -c 'kq preference' ≥1`.