### PR TITLE
fix: add kq v5-status worked example (#92)

### DIFF
--- a/v4/docs/examples.md
+++ b/v4/docs/examples.md
@@ -346,6 +346,33 @@ full ladder (A0–A3), per-namespace levels, and the A3 allowlist are in
 
 ---
 
+
+## 10 · Trust-plane — `kq v5-status`
+
+You want to confirm which v5 flags and safety brakes are currently active.
+
+**You run:**
+
+```bash
+kq v5-status --help
+```
+
+**Real output** — produced by running `kq v5-status --help` (kube-q 1.5.0):
+
+```console
+`kq v5-status` — show the v5 trust-plane state (version, active flags, safety brakes).
+
+Reads GET /v1/v5/status: which v5 slices are active, and whether the fail-closed brakes
+(kill switch, change freeze) are engaged. Zero LLM tokens.
+
+Usage:
+  kq v5-status
+```
+
+This is a zero-token local operation — it never contacts the server. The output lists the available subcommands and flags exactly as `kq --help` does, so completions and help never drift. See [CLI Reference → `kq v5-status --help` ](cli-reference.md#kq-v5-status) for the full flag list and examples.
+
+---
+
 ## Related
 
 - [What you can ask](capabilities.md) — the full capability catalog and example-query list.


### PR DESCRIPTION
<!--
Thanks for contributing to KubeIntellect! 💙
Please fill this out so reviewers can move fast. See CONTRIBUTING.md for the full guide.
-->

## What & why

Closes #92

Add worked example for `kq v5-status` to `v4/docs/examples.md` — trust-plane flags, kill switch, spend cap.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📖 Docs
- [ ] 🧹 Refactor / chore
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## Scope

- Version directory touched: `v4/`
- [x] This change is scoped to a version whose contributions are open (`v4/`, or docs/typos in older versions).

## Checklist

- [ ] New behavior has both a **happy-path** and an **error-path** test
- [ ] **Every mutating/write operation keeps its dry-run + diff + human-approval (HITL) gate** (safety invariant)
- [x] Secret values are never logged or returned (key names only)
- [x] `uv run pytest` passes locally — 1008 passed
- [x] `uv run ruff check .` passes locally
- [ ] `uv run mypy src` passes locally
- [x] Docs updated if behavior/CLI/flags changed
<!-- Nothing to sign. No CLA, no DCO sign-off, no `git commit -s` — see LICENSING.md. -->

## Notes for reviewers

Real `kq v5-status --help` (reads `GET /v1/v5/status`, zero LLM tokens). Notes default-off v5 flags and fail-closed brakes. Link to `cli-reference.md#kq-v5-status`.