### PR TITLE
fix: add liveness probe failing playbook (#95)

### DIFF
--- a/v4/docs/agent-behaviors.md
+++ b/v4/docs/agent-behaviors.md
@@ -123,7 +123,7 @@ detects a matching pattern in the snapshot, the coordinator's system prompt
 includes the playbook(s) inline — guiding it to follow proven steps before
 improvising.
 
-**Playbooks shipped (21):**
+**Playbooks shipped (22):**
 
 *Pod / container lifecycle*
 
@@ -421,7 +421,7 @@ triggers:
 - `detect: null` marks a playbook as **LLM-only** (no machine signal exists,
   or the signal is owned by another playbook).
 
-Of the 21 shipped playbooks, **18 compile to detectors**; 3 are LLM-only
+Of the 22 shipped playbooks, **19 compile to detectors**; 3 are LLM-only
 (`CommandHardcodedFailure` — disambiguated from CrashLoopBackOff only by
 reading the pod spec — `ServiceUnreachable`, and `NetworkPolicyBlocking`,
 where the packet is discarded in the CNI datapath so no machine signal

--- a/v4/docs/api-reference.md
+++ b/v4/docs/api-reference.md
@@ -231,7 +231,7 @@ Response:
 ```json
 {
   "sensorium": "active",
-  "detectors": 18,
+  "detectors": 19,
   "findings": [
     {
       "type": "finding",

--- a/v4/docs/architecture.md
+++ b/v4/docs/architecture.md
@@ -473,7 +473,7 @@ packages/
 │   │   ├── coordinator.py        — LLM decision + synthesis, tool trimmer, reflexion writes
 │   │   ├── memory_loader.py      — load pinned cluster context + failure-pattern hints
 │   │   └── subagent.py           — 4 specialist subagent runners
-│   ├── playbooks/                — YAML playbook library + loader (21 playbooks)
+│   ├── playbooks/                — YAML playbook library + loader (22 playbooks)
 │   ├── state.py                  — AgentState, SubagentInput, AgentFinding, RCAResult
 │   ├── workflow.py               — LangGraph graph, targeted_investigator, route_coordinator
 │   └── hitl.py                   — HITL approval/denial detection

--- a/v4/docs/capabilities.md
+++ b/v4/docs/capabilities.md
@@ -36,7 +36,7 @@ Metrics and logs are optional — without them, KubeIntellect still answers ever
 
 V4 also works *between* your questions:
 
-- **Zero-token known-failure detection** — the playbook library covers the 21 most common failures, and compiled detectors recognize 18 of them straight off the live cluster stream without spending a single LLM token. → [Agent Behaviors → V4 additions](agent-behaviors.md#v4-additions)
+- **Zero-token known-failure detection** — the playbook library covers the 22 most common failures, and compiled detectors recognize 19 of them straight off the live cluster stream without spending a single LLM token. → [Agent Behaviors → V4 additions](agent-behaviors.md#v4-additions)
 - **Self-opened investigations** — a firing detector opens its own investigation and publishes the report; how far it may go is set per namespace (A0–A3). → [Autonomous Operations](autonomy.md)
 - **Morning digest** — `kq digest` summarizes findings, autonomous investigations, and rollback points from the last N hours. → [Autonomous Operations → digest](autonomy.md#the-morning-digest)
 - **Tamper-evident audit replay** — every session is hash-chained in an append-only log; `kq replay <session-id>` reproduces it and verifies integrity. → [Flight Recorder & Replay](flight-recorder.md)
@@ -48,7 +48,7 @@ V4 also works *between* your questions:
 
 ## Failure patterns it recognizes
 
-KubeIntellect ships **21 built-in playbooks** — deterministic investigation
+KubeIntellect ships **22 built-in playbooks** — deterministic investigation
 recipes for the most common Kubernetes failures. When the cluster snapshot
 matches a pattern, the matching playbook guides the investigation automatically.
 You don't invoke these by name; they fire on their own.

--- a/v4/docs/glossary.md
+++ b/v4/docs/glossary.md
@@ -18,7 +18,7 @@ page where the concept is explained in depth.
 | **Memory loader** | The step that loads pinned, cross-session context (user prefs, past root causes, failure hints) into the prompt. Active only on PostgreSQL. |
 | **Cluster snapshot** | The pre-fetched picture of cluster health (pod list + Warning events) built at the start of every turn. Drives playbook matching and the snapshot sufficiency gate. |
 | **Snapshot sufficiency gate** | A soft bias that lets the agent answer healthy, list-shaped questions straight from the snapshot instead of re-querying. Modes: `off` / `lenient` / `strict`. See [Agent Behaviors](agent-behaviors.md#snapshot-sufficiency-gate). |
-| **Playbook** | A YAML investigation recipe for a known failure (CrashLoopBackOff, OOMKilled, …). When the snapshot matches, the playbook is injected into the prompt to guide the agent. 21 ship by default. See [Playbook library](agent-behaviors.md#playbook-library). |
+| **Playbook** | A YAML investigation recipe for a known failure (CrashLoopBackOff, OOMKilled, …). When the snapshot matches, the playbook is injected into the prompt to guide the agent. 22 ship by default. See [Playbook library](agent-behaviors.md#playbook-library). |
 | **Investigation plan** | A visible, up-front checklist the agent emits for queries needing 3+ steps, streamed as a `plan` event so the UI can show it. |
 | **RCA** | **Root-Cause Analysis** — the deep investigation path where four subagents run in parallel and the coordinator synthesizes their findings into one conclusion. |
 | **RCAResult** | The structured output of an RCA: root cause, confidence, supporting evidence, conflicting evidence, reasoning, and a recommended fix. See [What you can ask](capabilities.md#what-a-root-cause-answer-looks-like). |

--- a/v4/packages/kubeintellect-server/app/agent/playbooks/liveness_probe_failing.yaml
+++ b/v4/packages/kubeintellect-server/app/agent/playbooks/liveness_probe_failing.yaml
@@ -1,0 +1,26 @@
+name: LivenessProbeFailing
+detect:
+  watch_predicates:
+    - kind: Event
+      reason_regex: "^Unhealthy$"
+  promql:
+    - >-
+      increase(kube_pod_container_status_restarts_total[5m]) > 2
+      and
+      kube_pod_container_status_ready == 1
+  debounce_seconds: 180
+triggers:
+  - event_reason_regex: "Unhealthy"
+  - event_message_regex: "Liveness probe failed"
+investigation_steps:
+  - "kubectl get pods -A — check RESTARTS column; look for rising restarts with STATUS=Running (kubelet is killing a live container)."
+  - "kubectl describe pod <pod> -n <ns> — capture Events with Reason=Unhealthy and Message 'Liveness probe failed', and the livenessProbe spec (initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold)."
+  - "kubectl logs <pod> -n <ns> --previous — check if the app was actually healthy before the kubelet killed it (vs CrashLoopBackOff where it exits on its own)."
+  - "kubectl get events -n <ns> --field-selector reason=Unhealthy — correlate timestamps of probe failures with restarts."
+expected_evidence:
+  - "Events contain 'Liveness probe failed' with reason Unhealthy"
+  - "RESTARTS count rising while pod stays Running (not CrashLoopBackOff)"
+  - "Probe spec shows too-short initialDelaySeconds or timeoutSeconds for the app's startup time"
+recommended_fix_template: |
+  Pod <POD> in namespace <NS> is being restarted by the kubelet — liveness probe is failing (Unhealthy / Liveness probe failed) while the container would otherwise stay alive.
+  Increase initialDelaySeconds and/or timeoutSeconds to cover the app's real startup time, or fix the endpoint the probe checks. This is distinct from CrashLoopBackOff where the process exits on its own.

--- a/v4/tests/test_detectors.py
+++ b/v4/tests/test_detectors.py
@@ -194,7 +194,7 @@ class TestTerminatingStuckReliability:
 class TestPlaybookDetectorLoading:
     def test_eighteen_compiled_three_llm_only(self):
         detectors = load_detectors()
-        assert len(detectors) == 18
+        assert len(detectors) == 19
         names = {d.playbook for d in detectors}
         assert "CommandHardcodedFailure" not in names   # LLM-only by design
         assert "ServiceUnreachable" not in names


### PR DESCRIPTION
<!--
Thanks for contributing to KubeIntellect! 💙
Please fill this out so reviewers can move fast. See CONTRIBUTING.md for the full guide.
-->

## What & why

Closes #95

Add playbook `LivenessProbeFailing` — distinguishes liveness restarts (kubelet killing a live container) from `CrashLoopBackOff` (process exits on its own). Usually `initialDelaySeconds`/`timeoutSeconds` too short.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📖 Docs
- [ ] 🧹 Refactor / chore
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## Scope

- Version directory touched: `v4/`
- [x] This change is scoped to a version whose contributions are open (`v4/`, or docs/typos in older versions).

## Checklist

- [x] New behavior has both a **happy-path** and an **error-path** test — `yaml.safe_load` PASS + doc-claims
- [ ] **Every mutating/write operation keeps its dry-run + diff + human-approval (HITL) gate** (safety invariant)
- [x] Secret values are never logged or returned (key names only)
- [x] `uv run pytest` passes locally — 1008 passed (22 playbooks / 19 detectors docs + test updated)
- [x] `uv run ruff check .` passes locally
- [ ] `uv run mypy src` passes locally
- [ ] Docs updated if behavior/CLI/flags changed
<!-- Nothing to sign. No CLA, no DCO sign-off, no `git commit -s` — see LICENSING.md. -->

## Notes for reviewers

`v4/.../liveness_probe_failing.yaml` (`LivenessProbeFailing`, `Event Unhealthy + Liveness probe failed`, `increase(restarts[5m])>2`, `debounce_seconds: 180`). Steps: `kubectl get pods RESTARTS`, `describe pod` (probe spec), `logs --previous`, `get events Unhealthy`. Distinct from `crashloopbackoff.yaml`.