### PR TITLE
docs(playbooks): document the dead-predicate trap, require a firing test

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,6 +26,11 @@ Closes #
 ## Checklist
 
 - [ ] New behavior has both a **happy-path** and an **error-path** test
+- [ ] **Adding a playbook?** `triggers:` and `detect:` are two independent features — a test proves
+      the compiled `detect:` predicate **fires** on a realistic event and does **not** fire on a
+      neighbouring one. The counts and the schema check prove neither. (`kind:` is the observation
+      channel — `Pod` / `Event` / `Node` — never the Kubernetes object; use `involved_kind:` to
+      narrow the subject.)
 - [ ] **Every mutating/write operation keeps its dry-run + diff + human-approval (HITL) gate** (safety invariant)
 - [ ] Secret values are never logged or returned (key names only)
 - [ ] `uv run pytest` passes locally

--- a/v4/docs/agent-behaviors.md
+++ b/v4/docs/agent-behaviors.md
@@ -423,6 +423,36 @@ triggers:
 - `detect: null` marks a playbook as **LLM-only** (no machine signal exists,
   or the signal is owned by another playbook).
 
+!!! warning "`kind:` is the observation channel, not the Kubernetes object"
+    `kind:` selects which normalised stream the predicate reads — it is one of
+    exactly **`Pod`**, **`Event`**, **`Node`**, and nothing else. Writing the
+    object you care about (`kind: PersistentVolumeClaim`, `kind: Deployment`)
+    parses, loads into the registry, counts toward the detector total and passes
+    the schema check — and then matches nothing, ever, because
+    `WatchPredicate.matches()` falls through to `False` for any other value.
+    To narrow an Event to a subject, use `involved_kind:`:
+
+    ```yaml
+    - kind: Event                              # the channel
+      reason_regex: "^(FailedBinding|ProvisioningFailed)$"
+      involved_kind: PersistentVolumeClaim     # the object
+    ```
+
+    **`triggers:` and `detect:` are two independent features.** A playbook can
+    have a perfect `triggers:` block and a permanently dead `detect:` block; only
+    the zero-token detection is lost, and nothing goes red. So a playbook PR needs
+    a test that the compiled predicate *fires* on a realistic event and does *not*
+    fire on a neighbouring one — see `TestPvcPendingDetector` and
+    `TestProbeDetectorsDoNotCrossFire` in `tests/test_detectors.py` for the shape.
+    Two class guards (`test_every_watch_predicate_uses_a_known_observation_kind`,
+    `test_no_reason_regex_alternative_contains_whitespace`) catch the two ways
+    this has actually happened.
+
+    Where a reason is shared by more than one failure — the kubelet emits
+    `Unhealthy` for *both* readiness and liveness probes — the `message_regex`
+    co-condition is what separates them. Without it, two playbooks fire on one
+    event and the operator is told about a restart loop that is not happening.
+
 Of the 23 shipped playbooks, **20 compile to detectors**; 3 are LLM-only
 (`CommandHardcodedFailure` — disambiguated from CrashLoopBackOff only by
 reading the pod spec — `ServiceUnreachable`, and `NetworkPolicyBlocking`,


### PR DESCRIPTION
Follow-up to #129. Three playbooks have now shipped a `detect:` block that could never fire — #114 (whitespace inside a regex alternation), #127 (`kind:` naming the Kubernetes object rather than the observation channel) and #128 (a shared event reason with no message co-condition). Each time `triggers:` worked, so the playbook looked alive, and each time every gate stayed green because nothing asserts a compiled predicate can actually match.

The class guards landed in #129. This writes the trap down where an author is already reading — next to the schema in `agent-behaviors.md` — and adds the requirement to the PR checklist, so the next contributor is told up front instead of finding out in review.

No code change. `mkdocs build` clean, `test_doc_claims` and `test_detectors` pass.