### PR TITLE
ci: run both suites on Python 3.14 (non-blocking) — unblocks the #71 decision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,52 @@ jobs:
         working-directory: ${{ matrix.workdir }}
         run: uv run --python 3.13 python -m pytest ${{ matrix.path }} -q
 
+  test-candidate:
+    name: Tests (${{ matrix.suite }} · py3.14)
+    runs-on: ubuntu-latest
+    # The interpreter the project does NOT ship on yet — this job exists so the
+    # decision on #71 (bump the runtime base image to python:3.14-slim) rests on
+    # evidence from CI rather than on one laptop.
+    #
+    # Deliberately NOT a required check: 3.14 is ahead of what any container or
+    # `pip install` currently resolves to, so a red run here is information, not
+    # a reason to block an unrelated PR. Promote it to required in the same
+    # change that bumps the Dockerfile, never before — the point of the py3.13
+    # job (#62) was that CI must cover whatever actually ships.
+    #
+    # `continue-on-error` keeps that true even if a transient wheel gap appears:
+    # the result is visible on every PR, and it cannot gate anyone.
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: server
+            workdir: v4
+            path: tests/
+          - suite: kube-q CLI
+            workdir: v4/packages/kube-q
+            path: tests/
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        run: pip install "uv==${UV_VERSION}"
+
+      # Same reason as the py3.13 job: without `--python 3.14` uv rebuilds the
+      # interpreter recorded in uv.lock and this job silently duplicates it.
+      - name: Sync dependencies
+        working-directory: v4
+        run: uv sync --python 3.14
+
+      - name: Run pytest
+        working-directory: ${{ matrix.workdir }}
+        run: uv run --python 3.14 python -m pytest ${{ matrix.path }} -q
+
   install-smoke:
     name: Install smoke test
     runs-on: ubuntu-latest


### PR DESCRIPTION
#71 (Dependabot: bump the v4 runtime base image `python:3.13-slim` → `3.14-slim`) has been parked as `needs-decision` since 2026-08-10. The blocker was never whether it works — both suites pass on 3.14 — it was that **CI has never run 3.14**, so merging it would stop the pipeline covering the interpreter that actually ships, which is the exact hole the py3.13 job was added to close (#62).

This adds `Tests (… · py3.14)` for both suites.

**Deliberately not a required check**, and `continue-on-error: true`. 3.14 is ahead of what any container or `pip install` resolves to today, so a red run here is information, not grounds to block an unrelated PR. It should be promoted to required in the *same* change that bumps the Dockerfile — not before.

Added as a separate job rather than a `python-version` matrix axis, for the same reason the py3.13 job is separate: an axis renames `Tests (server)` → `Tests (server · py3.12)`, and branch protection matches required checks by name, so every open PR would block on a check that no longer reports. Verified none of the eight existing job names changed.

**Evidence so far:** on this machine, `uv sync` resolved a 3.14 environment and both suites passed there — server **1020 passed**, `kq` **312 passed**. This PR is what turns that into a repeatable signal.

Does not merge #71. That is a production runtime upgrade and stays a maintainer decision.