### PR TITLE
fix(roadmap): correct the playbook counts, and gate ROADMAP against drift

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,7 @@ The `v4/` platform is the current line and the only one you should deploy.
 - Conversational diagnosis correlating **kubectl + Prometheus + Loki**.
 - **Human-in-the-loop approval gate** with RBAC (superadmin / admin / operator / readonly) on
   every mutating action, enforced server-side at the mutating chokepoint.
-- **20 declarative failure playbooks** (`detect → investigate → remediate`), 17 of which compile
+- **23 declarative failure playbooks** (`detect → investigate → remediate`), 20 of which compile
   to zero-token detectors.
 - **Zero-token detection** — a detector engine over a kubectl `--watch` sensorium fires
   findings without invoking the LLM.
@@ -51,7 +51,7 @@ These are concrete, scoped, and mostly open to contribution.
 | **Composable detectors** — AND / NOT / temporal windows | Open | [#21](https://github.com/MSKazemi/kubeintellect/issues/21) ✅ |
 | **PromQL execution in playbook `detect` blocks** | Open | [#20](https://github.com/MSKazemi/kubeintellect/issues/20) ✅ |
 | **Temporal KG ingesting nodes / events / PVCs** | Open | [#19](https://github.com/MSKazemi/kubeintellect/issues/19) ✅ |
-| Grow the **playbook library** beyond 20 | Ongoing — a playbook is one YAML file; 18 → 20 in Aug 2026 via [#108](https://github.com/MSKazemi/kubeintellect/pull/108) and [#112](https://github.com/MSKazemi/kubeintellect/pull/112) | [#13](https://github.com/MSKazemi/kubeintellect/issues/13) ✅ |
+| Grow the **playbook library** beyond 23 | Ongoing — a playbook is one YAML file; 18 → 23 in Aug 2026 via [#108](https://github.com/MSKazemi/kubeintellect/pull/108), [#112](https://github.com/MSKazemi/kubeintellect/pull/112), [#114](https://github.com/MSKazemi/kubeintellect/pull/114), [#127](https://github.com/MSKazemi/kubeintellect/pull/127) and [#128](https://github.com/MSKazemi/kubeintellect/pull/128) | [#13](https://github.com/MSKazemi/kubeintellect/issues/13) ✅ |
 
 ## Housekeeping — known debt, stated plainly
 

--- a/v4/scripts/check_doc_claims.py
+++ b/v4/scripts/check_doc_claims.py
@@ -26,6 +26,9 @@ from pathlib import Path
 # Repo layout: this file is v4/scripts/check_doc_claims.py
 _V4 = Path(__file__).resolve().parent.parent
 _DOCS = _V4 / "docs"
+# Repo-root docs make the same derived claims and drift the same way. ROADMAP.md
+# sat three playbooks behind for exactly as long as nothing checked it.
+_ROOT = _V4.parent
 
 
 # ── Canonical values, read straight from the code ────────────────────────────
@@ -76,7 +79,19 @@ def _canonical() -> Canonical:
 # ── Checks ───────────────────────────────────────────────────────────────────
 
 
+_ROOT_PREFIX = "root:"
+
+
 def _read(doc: str) -> str:
+    """Read a doc, by default from ``v4/docs/``.
+
+    A name prefixed ``root:`` resolves from the repo root instead, so root-level
+    surfaces like ``ROADMAP.md`` can be checked alongside the v4 docs. The prefix
+    is explicit on purpose — an implicit fallback would turn a typo in a docs
+    filename into a confusing lookup somewhere else.
+    """
+    if doc.startswith(_ROOT_PREFIX):
+        return (_ROOT / doc[len(_ROOT_PREFIX):]).read_text(encoding="utf-8")
     return (_DOCS / doc).read_text(encoding="utf-8")
 
 
@@ -118,6 +133,18 @@ def run_checks() -> list[str]:
     errors += _check_number(
         "architecture.md", r"\((\d+) playbooks\)", pc, "playbook count"
     )
+    # Repo-root ROADMAP.md — the surface a first-time visitor reads, and the one
+    # that had drifted furthest (it claimed 20 when the library was 23) because
+    # nothing checked it.
+    errors += _check_number(
+        "root:ROADMAP.md",
+        r"\*\*(\d+) declarative failure playbooks\*\*",
+        pc,
+        "playbook count",
+    )
+    errors += _check_number(
+        "root:ROADMAP.md", r"playbook library\*\* beyond (\d+)", pc, "playbook count"
+    )
 
     dc = c.detector_count
     errors += _check_number(
@@ -125,6 +152,9 @@ def run_checks() -> list[str]:
     )
     errors += _check_number(
         "api-reference.md", r'"detectors":\s*(\d+)', dc, "detector count"
+    )
+    errors += _check_number(
+        "root:ROADMAP.md", r"(\d+) of which compile", dc, "detector count"
     )
 
     fc = c.flag_count


### PR DESCRIPTION
`ROADMAP.md` claimed **20 playbooks / 17 detectors**. The real numbers are **23 / 20** — it went stale at #114 and drifted two further in #129.

The interesting part is *why* it was allowed to. `check_doc_claims.py` resolves every doc against `v4/docs/`, so the six in-docs claims are gated and the repo-root ROADMAP — the surface a first-time visitor actually reads — was the one thing nothing checked. Every other count in the project is guarded; this one was guarded by remembering.

The checker now resolves a `root:` prefix from the repo root and asserts all three ROADMAP claims (both playbook counts and the detector count). The prefix is explicit rather than an implicit fallback, so a typo in a `v4/docs/` filename still fails loudly instead of silently looking somewhere else.

**Verified in the failing direction first** — against the old numbers:

```
FAIL root:ROADMAP.md: playbook count says 20, code says 23 (/\*\*(\d+) declarative failure playbooks\*\*/)
FAIL root:ROADMAP.md: playbook count says 20, code says 23 (/playbook library\*\* beyond (\d+)/)
FAIL root:ROADMAP.md: detector count says 17, code says 20 (/(\d+) of which compile/)
```

Then green after the fix. `ruff` clean, `test_doc_claims` passes.

Also updates the "grow the playbook library" row to list all five PRs that grew it this month (#108, #112, #114, #127, #128).