### PR TITLE
fix(cortex): retry triage when the reply is not valid JSON

### DIFF
--- a/v4/packages/kubeintellect-server/app/cortex/graph.py
+++ b/v4/packages/kubeintellect-server/app/cortex/graph.py
@@ -104,12 +104,20 @@ diagnosed), what was done or recommended, and concrete next steps. Be precise
 and cite the actual object names/namespaces/exit codes you observed. No tool
 calls — answer only."""
 
+# Triage repair loop (#22): the triage tier answers in strict JSON; when the
+# reply does not parse, we feed it back with a corrective hint and retry before
+# falling back to the investigate default.
+_TRIAGE_MAX_PARSE_ATTEMPTS = 3
+_TRIAGE_REPAIR_HINT = (
+    "Your previous response was not valid triage JSON. Reply with ONLY a JSON "
+    'object matching the schema: {"mode": "chat" | "investigate", '
+    '"plan": ["step 1", ...]}. No prose, no markdown fences.'
+)
+
 
 # ── Nodes ─────────────────────────────────────────────────────────────────────
 
 async def triage(state: CortexState, config: RunnableConfig) -> dict:
-    from app.cortex.models import get_triage_llm
-
     session_id = state["session_id"]
     await emit(session_id, StatusEvent(
         phase="analyzing", message="Triaging request…", session_id=session_id,
@@ -128,12 +136,7 @@ async def triage(state: CortexState, config: RunnableConfig) -> dict:
         SystemMessage(content=_TRIAGE_SYSTEM + "\n\n" + "\n\n".join(p for p in context_parts if p)),
         HumanMessage(content=user_text),
     ]
-    try:
-        reply = await get_triage_llm().ainvoke(prompt, config)
-        parsed = _parse_triage_json(str(reply.content))
-    except Exception as exc:
-        logger.warning(f"cortex.triage failed ({exc}) — defaulting to investigate")
-        parsed = {"mode": "investigate", "plan": []}
+    parsed = await _triage_with_repair(prompt, config)
 
     mode = parsed.get("mode", "investigate")
     steps = [
@@ -156,6 +159,46 @@ async def triage(state: CortexState, config: RunnableConfig) -> dict:
         "turn_start_index": len(state.get("messages", [])),
         "turn_start_monotonic": time.monotonic(),
     }
+
+
+async def _triage_with_repair(
+    prompt: list[BaseMessage], config: RunnableConfig
+) -> dict:
+    """Invoke the triage tier with a bounded repair loop (#22).
+
+    The triage tier answers in strict JSON. When the reply does not parse,
+    feed it back with a corrective hint and retry — up to
+    _TRIAGE_MAX_PARSE_ATTEMPTS total calls — before falling back to the
+    investigate default, so one malformed reply no longer silently discards
+    the request.
+    """
+    from app.cortex.models import get_triage_llm
+
+    for attempt in range(1, _TRIAGE_MAX_PARSE_ATTEMPTS + 1):
+        try:
+            reply = await get_triage_llm().ainvoke(prompt, config)
+        except Exception as exc:
+            logger.warning(
+                f"cortex.triage attempt {attempt} failed ({exc}) — defaulting to investigate"
+            )
+            return {"mode": "investigate", "plan": []}
+        parsed = _parse_triage_json_strict(str(reply.content))
+        if parsed is not None:
+            return parsed
+        if attempt == _TRIAGE_MAX_PARSE_ATTEMPTS:
+            break
+        logger.warning(
+            f"cortex.triage attempt {attempt} returned unparseable JSON — retrying with a repair hint"
+        )
+        prompt = [
+            *prompt,
+            AIMessage(content=str(reply.content)),
+            HumanMessage(content=_TRIAGE_REPAIR_HINT),
+        ]
+    logger.warning(
+        f"cortex.triage exhausted {_TRIAGE_MAX_PARSE_ATTEMPTS} attempts — defaulting to investigate"
+    )
+    return {"mode": "investigate", "plan": []}
 
 
 async def gather_once(state: CortexState, config: RunnableConfig) -> dict:
@@ -485,17 +528,27 @@ def build_cortex_graph() -> StateGraph:
 _JSON_RE = re.compile(r"\{.*\}", re.DOTALL)
 
 
-def _parse_triage_json(text: str) -> dict:
+def _parse_triage_json_strict(text: str) -> dict | None:
+    """Parse a triage reply into a validated plan dict, or None when the
+    reply is not usable triage JSON (no JSON block, malformed JSON, or an
+    unrecognised mode). The repair loop uses this to tell "bad reply" apart
+    from "investigate" as a deliberate answer."""
     match = _JSON_RE.search(text)
     if not match:
-        return {"mode": "investigate", "plan": []}
+        return None
     try:
         data = json.loads(match.group(0))
     except json.JSONDecodeError:
-        return {"mode": "investigate", "plan": []}
+        return None
     if not isinstance(data, dict) or data.get("mode") not in ("chat", "investigate"):
-        return {"mode": "investigate", "plan": []}
+        return None
     return data
+
+
+def _parse_triage_json(text: str) -> dict:
+    """Parse a triage reply, falling back to investigate on failure (kept
+    for callers that want the old lenient behaviour)."""
+    return _parse_triage_json_strict(text) or {"mode": "investigate", "plan": []}
 
 
 def _last_user_text(state) -> str:

--- a/v4/tests/test_cortex.py
+++ b/v4/tests/test_cortex.py
@@ -197,3 +197,63 @@ class TestRoundBudgetBoundary:
         assert closers and closers[0].tool_call_id == "dangle-1"
         returned_tool_msgs = [m for m in out["messages"] if isinstance(m, ToolMessage)]
         assert returned_tool_msgs and returned_tool_msgs[0].tool_call_id == "dangle-1"
+
+class TestTriageRetry:
+    """Issue #22: a bounded retry/repair when the triage reply is not valid JSON."""
+
+    async def test_retries_once_when_first_reply_is_malformed(self, mocker):
+        mocker.patch.object(cx, "emit")
+        fake_llm = mocker.AsyncMock()
+        fake_llm.ainvoke = mocker.AsyncMock(side_effect=[
+            mocker.MagicMock(content="oops { mode: chat } not json"),
+            mocker.MagicMock(content='{"mode": "chat", "plan": []}'),
+        ])
+        mocker.patch("app.cortex.models.get_triage_llm", return_value=fake_llm)
+
+        out = await cx.triage(_state(), {})
+
+        assert out["triage_mode"] == "chat"
+        assert fake_llm.ainvoke.await_count == 2
+
+    async def test_repair_hint_passed_on_retry(self, mocker):
+        mocker.patch.object(cx, "emit")
+        sent_prompts = []
+        fake_llm = mocker.AsyncMock()
+
+        async def _ainvoke(prompt, config):
+            sent_prompts.append(prompt)
+            if len(sent_prompts) == 1:
+                return mocker.MagicMock(content="garbage {")
+            return mocker.MagicMock(content='{"mode": "chat", "plan": []}')
+
+        fake_llm.ainvoke = _ainvoke
+        mocker.patch("app.cortex.models.get_triage_llm", return_value=fake_llm)
+
+        await cx.triage(_state(), {})
+
+        assert len(sent_prompts) == 2
+        retry_prompt = sent_prompts[1]
+        assert any(
+            "not valid triage JSON" in m.content
+            for m in retry_prompt
+            if isinstance(m, HumanMessage)
+        )
+
+    async def test_falls_back_to_investigate_after_max_attempts(self, mocker):
+        mocker.patch.object(cx, "emit")
+        fake_llm = mocker.AsyncMock()
+        fake_llm.ainvoke = mocker.AsyncMock(
+            return_value=mocker.MagicMock(content="still not json"))
+        mocker.patch("app.cortex.models.get_triage_llm", return_value=fake_llm)
+
+        out = await cx.triage(_state(), {})
+
+        assert out["triage_mode"] == "investigate"
+        assert fake_llm.ainvoke.await_count == cx._TRIAGE_MAX_PARSE_ATTEMPTS
+
+    def test_strict_parser_distinguishes_failure_from_valid(self):
+        assert cx._parse_triage_json_strict("not json") is None
+        assert cx._parse_triage_json_strict('{"mode": "nonsense"}') is None
+        assert cx._parse_triage_json_strict(
+            '{"mode": "chat", "plan": []}')["mode"] == "chat"
+


### PR DESCRIPTION
## What & why

Closes #22

The triage tier is told to answer in strict JSON, but when the model actually returns something unparseable, we just swallowed it and defaulted to investigate — no second chance. For a tier whose whole job is classifying the request, that silently throws away the user's intent on a single bad reply.

This adds a bounded repair loop: if the reply doesn't parse, we feed it back with a corrective hint and retry, up to 3 total calls. Only after that do we fall back to investigate, same as before. The old behavior (exception -> immediate fallback) is preserved.

To make the loop work I split the parser in two: `_parse_triage_json_strict` returns `None` when the reply isn't usable JSON (so the loop can tell "bad reply" from a deliberate `investigate` answer), and `_parse_triage_json` keeps its old lenient contract for existing callers.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation
- [ ] 🧹 Refactor / chore
- [ ] ⚡ Performance
- [ ] 🔒 Security

## Scope

- Version directory touched: `v4/`
- [x] This change is scoped to a version whose contributions are open (`v4/`, or docs/typos in older versions).

## Checklist

- [x] New behavior has both a **happy-path** and an **error-path** test
- [x] **Every mutating/write operation keeps its dry-run + diff + human-approval (HITL) gate** (safety invariant)
- [x] Secret values are never logged or returned (key names only)
- [x] `uv run pytest` passes locally
- [x] `uv run ruff check .` passes locally
- [x] `uv run mypy src` passes locally
- [x] Docs updated if behavior/CLI/flags changed

## How to test

```bash
cd v4
uv run python -m pytest tests/test_cortex.py -q   # 20 passed
```

The new `TestTriageRetry` class covers: malformed-then-valid reply (retries once and uses the valid plan), repair hint actually reaching the retried prompt, and exhausting all attempts falling back to investigate. The malformed-then-valid test fails on the pre-fix code (single call, wrong mode) and passes after.

Full gates run locally: `ruff check` clean, `mypy` 0 errors across 171 files, `make check-syntax` OK. Note the full `pytest tests/` run has 46 failures (playbooks/detectors/doc-claims), but they fail identically on a clean checkout of `main` — I diffed the two failure sets and they're the same list, so nothing here adds a new failure.

## Notes for reviewers

The retry appends the model's malformed reply plus the hint as messages, so the second call sees what went wrong rather than guessing. 3 attempts felt like the right bound: enough for a real recovery, small enough that a broken model doesn't multiply latency much (the tier is the cheap small model anyway).

AI assistance: I used AI tooling to help draft the repair loop and the tests, and reviewed the diff and gate output before submitting.
