### PR TITLE
chore(server): modernize typing imports and annotations (UP006, UP035)

### DIFF
--- a/v4/packages/kubeintellect-server/app/agent/playbooks/loader.py
+++ b/v4/packages/kubeintellect-server/app/agent/playbooks/loader.py
@@ -18,9 +18,9 @@ Schema (one .yaml file per playbook):
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable
 
 import yaml
 

--- a/v4/packages/kubeintellect-server/app/api/v1/endpoints/chat_completions.py
+++ b/v4/packages/kubeintellect-server/app/api/v1/endpoints/chat_completions.py
@@ -20,7 +20,7 @@ import asyncio
 import json
 import time
 import uuid
-from typing import AsyncIterator
+from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse

--- a/v4/packages/kubeintellect-server/app/autonomy/promotion_engine.py
+++ b/v4/packages/kubeintellect-server/app/autonomy/promotion_engine.py
@@ -14,8 +14,9 @@ against the P0 replay fixtures.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Callable, Optional
+from typing import Optional
 
 from app.autonomy.promotion_stats import (
     Event,

--- a/v4/packages/kubeintellect-server/app/core/llm.py
+++ b/v4/packages/kubeintellect-server/app/core/llm.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import os
 from functools import lru_cache
-from typing import Any, List, Type
+from typing import Any
 
 from langchain_core.language_models import BaseChatModel
 from pydantic import SecretStr
@@ -20,10 +20,10 @@ def _secret(value: str | None) -> SecretStr | None:
 
 # Resolved once at import time so the ImportError warning fires only on startup,
 # not on every request.  None = not yet resolved, False = unavailable.
-_LangfuseCallbackHandler: Type[Any] | None | bool = None
+_LangfuseCallbackHandler: type[Any] | None | bool = None
 
 
-def _resolve_langfuse() -> Type[Any] | None:
+def _resolve_langfuse() -> type[Any] | None:
     global _LangfuseCallbackHandler
     if _LangfuseCallbackHandler is not None:
         return None if _LangfuseCallbackHandler is False else _LangfuseCallbackHandler  # type: ignore[return-value]
@@ -37,7 +37,7 @@ def _resolve_langfuse() -> Type[Any] | None:
         return None
 
 
-def get_langfuse_callbacks() -> List[Any]:
+def get_langfuse_callbacks() -> list[Any]:
     """Return [CallbackHandler()] if Langfuse tracing is enabled, else [].
 
     Langfuse v4 reads LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY / LANGFUSE_HOST from

--- a/v4/packages/kubeintellect-server/app/cortex/change_rca.py
+++ b/v4/packages/kubeintellect-server/app/cortex/change_rca.py
@@ -13,8 +13,9 @@ The ranking/rendering here is pure and fully tested against injected changes.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Optional
 
 from app.utils.logger import get_logger
 

--- a/v4/packages/kubeintellect-server/app/cortex/harness/runner.py
+++ b/v4/packages/kubeintellect-server/app/cortex/harness/runner.py
@@ -20,7 +20,8 @@ Stability contract (this is the "most stable" bar the whole feature is default-o
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Awaitable, Callable, Optional
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Optional
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage

--- a/v4/packages/kubeintellect-server/app/cortex/responsiveness.py
+++ b/v4/packages/kubeintellect-server/app/cortex/responsiveness.py
@@ -18,8 +18,9 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Awaitable, Callable, Optional
+from typing import Optional
 
 from app.streaming.emitter import Event, StatusEvent
 from app.streaming.emitter import emit as _default_emit

--- a/v4/packages/kubeintellect-server/app/detectors/agentic_gpu_collector.py
+++ b/v4/packages/kubeintellect-server/app/detectors/agentic_gpu_collector.py
@@ -9,7 +9,8 @@ Prometheus; the default reads the live PromQL endpoint.
 
 from __future__ import annotations
 
-from typing import Callable, Optional
+from collections.abc import Callable
+from typing import Optional
 
 from app.detectors.agentic_gpu import (
     AgentSignal,

--- a/v4/packages/kubeintellect-server/app/memory/change_ledger.py
+++ b/v4/packages/kubeintellect-server/app/memory/change_ledger.py
@@ -14,12 +14,12 @@ only needs *recent* changes, and a restart losing them degrades gracefully (empt
 from __future__ import annotations
 
 from collections import defaultdict, deque
-from typing import Deque, Optional
+from typing import Optional
 
 from app.cortex.change_rca import ChangeRecord, _empty_source, set_change_source
 
 _MAX_PER_CLUSTER = 200
-_ledger: dict[str, Deque[ChangeRecord]] = defaultdict(lambda: deque(maxlen=_MAX_PER_CLUSTER))
+_ledger: dict[str, deque[ChangeRecord]] = defaultdict(lambda: deque(maxlen=_MAX_PER_CLUSTER))
 _installed = False
 
 # kubectl mutating verb → change kind.

--- a/v4/packages/kubeintellect-server/app/memory/file_plane.py
+++ b/v4/packages/kubeintellect-server/app/memory/file_plane.py
@@ -11,8 +11,9 @@ injectable orchestrator (fetchers + writer) so the whole thing is unit-testable 
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, Optional
 
 from app.utils.logger import get_logger
 

--- a/v4/packages/kubeintellect-server/app/memory/fleet_exchange.py
+++ b/v4/packages/kubeintellect-server/app/memory/fleet_exchange.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from collections import defaultdict, deque
 from dataclasses import dataclass
-from typing import Deque, Optional
+from typing import Optional
 
 _MAX_PER_TENANT = 500
 
@@ -28,7 +28,7 @@ class FleetEntry:
 
 
 # tenant → ring buffer of entries. Partitioned by tenant so a read can NEVER cross tenants.
-_store: dict[str, Deque[FleetEntry]] = defaultdict(lambda: deque(maxlen=_MAX_PER_TENANT))
+_store: dict[str, deque[FleetEntry]] = defaultdict(lambda: deque(maxlen=_MAX_PER_TENANT))
 
 
 def publish(entry: FleetEntry) -> None:

--- a/v4/packages/kubeintellect-server/app/memory/writeback.py
+++ b/v4/packages/kubeintellect-server/app/memory/writeback.py
@@ -14,8 +14,9 @@ write-back *mechanism* here is complete and takes whatever signals it is given.
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, Optional
 
 from app.utils.logger import get_logger
 

--- a/v4/packages/kubeintellect-server/app/sensorium/change_watchdog.py
+++ b/v4/packages/kubeintellect-server/app/sensorium/change_watchdog.py
@@ -12,8 +12,9 @@ exactly as prospective memory defers its dispatch.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Optional
 
 from app.cortex.change_rca import ChangeRecord
 from app.utils.logger import get_logger

--- a/v4/packages/kubeintellect-server/app/sensorium/watchdog_dispatch.py
+++ b/v4/packages/kubeintellect-server/app/sensorium/watchdog_dispatch.py
@@ -12,7 +12,8 @@ injectable so the wiring is unit-testable without an LLM.
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Awaitable, Callable, Optional
+from collections.abc import Awaitable, Callable
+from typing import Any, Optional
 
 from langchain_core.messages import HumanMessage
 

--- a/v4/packages/kubeintellect-server/app/tools/aci/gitops.py
+++ b/v4/packages/kubeintellect-server/app/tools/aci/gitops.py
@@ -12,8 +12,9 @@ without git, gh, or a network.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Optional
 
 from app.tools.aci.fix_pr import FixPR
 

--- a/v4/packages/kubeintellect-server/app/tools/aci/transactional.py
+++ b/v4/packages/kubeintellect-server/app/tools/aci/transactional.py
@@ -12,8 +12,9 @@ path — reachable only for chokepoint-authorized, reversible classes).
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Optional
 
 from app.tools.aci.postcondition import PostconditionResult
 


### PR DESCRIPTION
## What & why

This is the typing-modernization slice of the ruff 0.16 backlog from #75 (item 3, `UP006` / `UP035`). The server package still pulls `List`/`Type`/`Deque` out of `typing` and uses `typing.{Callable, Awaitable, Iterable, AsyncIterator}` where the stdlib equivalents are the modern spelling.

All 16 files already import `from __future__ import annotations`, and every name being moved is only used in annotations or type aliases, so this is purely mechanical with no runtime behavior change:

- `typing.List` / `typing.Type` -> `list` / `type` (`core/llm.py`)
- `typing.Deque` -> `collections.deque` (`memory/change_ledger.py`, `memory/fleet_exchange.py`)
- `typing.Callable` / `Awaitable` / `Iterable` / `AsyncIterator` -> `collections.abc` (13 files)

Refs #75 (this family; the rest of the backlog stays for its own PRs).

## Type of change

- [x] Refactor / chore

## Scope

- Version directory touched: `v4/`
- [x] This change is scoped to a version whose contributions are open (`v4/`)

## Checklist

- [ ] New behavior has both a happy-path and an error-path test - no behavior change, annotation-only
- [x] `uv run pytest` passes locally - see Notes
- [x] `uv run ruff check .` passes locally
- [x] `uv run mypy src` passes locally
- [ ] Docs updated if behavior/CLI/flags changed - none

## Notes for reviewers

Gates run from `v4/`:

| Gate | Result |
|---|---|
| `uv run ruff check packages/kubeintellect-server/app/ packages/ki-protocol/` | clean |
| `uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube-q/kube_q` | 0 errors (171 files) |
| `uvx ruff@latest check v4 --select UP006,UP035` | clean - family cleared |
| `uv run python -m pytest tests/ -q` | 1020 passed with `PYTHONUTF8=1` |

Two environment notes, both pre-existing and unrelated to this change:

1. **Windows locale vs the playbook YAMLs.** On this machine the server suite fails a batch of playbook tests unless `PYTHONUTF8=1` is set, because the playbook loader reads the YAML files without an explicit encoding and this Windows locale defaults to GBK (the files are UTF-8). It reproduces on a clean checkout of `main` with zero changes, and CI runs on Ubuntu so it never sees it. I'll send a small separate PR for the loader (`path.read_text(encoding="utf-8")`).
2. **kube-q file-mode test.** 311/312 - the one failure is `test_load_or_create_user_id_explicit`, which asserts a POSIX mode (`0o600`) that Windows does not enforce. Passes on Linux CI.

Used an AI coding assistant for parts of the mechanical edit; the change itself is small and I ran all the gates above locally. Happy to explain any line.
