### PR TITLE
fix(playbooks): read playbook YAML as UTF-8 so non-UTF-8 locales don't drop every playbook

### DIFF
--- a/v4/packages/kubeintellect-server/app/agent/playbooks/loader.py
+++ b/v4/packages/kubeintellect-server/app/agent/playbooks/loader.py
@@ -63,7 +63,7 @@ def _compile_trigger(raw: dict) -> Trigger:
 
 
 def _load_one(path: Path) -> Playbook:
-    data = yaml.safe_load(path.read_text())
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
         raise ValueError(f"Playbook {path.name} must be a YAML mapping")
     name = data.get("name")

--- a/v4/tests/test_playbooks.py
+++ b/v4/tests/test_playbooks.py
@@ -342,3 +342,34 @@ default     12s         Warning   FailedComputeMetricsReplicas   horizontalpodau
 def test_match_hpa_not_scaling_by_missing_cpu_request() -> None:
     matched = match_playbooks(HEALTHY_PODS, HPA_MISSING_CPU_REQUEST_EVENTS)
     assert "HPANotScaling" in matched
+
+
+def test_playbook_yaml_reads_as_utf8_regardless_of_locale(monkeypatch, tmp_path) -> None:
+    """Playbook YAML must decode as UTF-8 even when the platform default encoding is
+    not UTF-8 (Windows GBK/cp936, POSIX C locale). Regression test for #136."""
+    import pathlib
+
+    from app.agent.playbooks.loader import _load_one
+
+    real_read_text = pathlib.Path.read_text
+    encodings: list[object] = []
+
+    def recording_read_text(self, *args, **kwargs):
+        encodings.append(kwargs.get("encoding"))
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "read_text", recording_read_text)
+    yaml_file = tmp_path / "utf8_playbook.yaml"
+    yaml_file.write_bytes(
+        (
+            "name: Utf8Playbook\n"
+            "investigation_steps:\n"
+            '  - "Investigate the em dash \u2014 in this step."\n'
+            "recommended_fix_template: >\n"
+            "  Fix it.\n"
+        ).encode("utf-8")
+    )
+    playbook = _load_one(yaml_file)
+    assert playbook.name == "Utf8Playbook"
+    assert "\u2014" in playbook.investigation_steps[0]
+    assert encodings == ["utf-8"]


### PR DESCRIPTION
## What & why

Fixes the playbook loader on non-UTF-8 locales. `loader.py` reads the playbook YAML with `path.read_text()` (platform-default encoding), but the files are UTF-8 — they contain em-dashes in the investigation steps and fix templates. On Windows (GBK/cp1252) or a POSIX C locale, every read raises `UnicodeDecodeError`, the per-file handler swallows it, and the agent silently runs with 2 of the 23 playbooks (only the ASCII-only ones load).

Closes #136

### Before

```
playbook_load_failed file=crashloopbackoff.yaml error=UnicodeDecodeError('gbk', ..., 'illegal multibyte sequence')
...
playbooks loaded: ['QuotaExceeded', 'WebhookAdmissionRejected']
```

### After

```
playbooks loaded: ['CrashLoopBackOff', 'ImagePullBackOff', 'NetworkPolicyBlocking', 'DeploymentRolloutStuck', ...]
```

## Type of change

- [x] Bug fix

## Scope

- Version directory touched: `v4/`
- [x] This change is scoped to a version whose contributions are open (`v4/`)

## Checklist

- [x] New behavior has both a happy-path and an error-path test - the existing `tests/test_playbooks.py` suite covers this (26 tests fail before, all pass after; `test_all_playbooks_load` asserts the full expected set)
- [x] `uv run pytest` passes locally - 1021 passed
- [x] `uv run ruff check .` passes locally
- [x] `uv run mypy src` passes locally - 0 errors (171 files)
- [ ] Docs updated if behavior/CLI/flags changed - none

## Notes for reviewers

Verified on this Windows machine (GBK locale): the full server suite was failing ~46 tests before this change and passes 1021/1021 after, without any `PYTHONUTF8` or env tweaks. On Ubuntu CI this is a no-op (the default encoding is already UTF-8), which is why it has not surfaced there.

Small fix, and I ran all four gates above locally. Happy to explain.

Disclosure: developed with AI-assisted tooling (used as a coding aid); the change and tests were reviewed and all four gates were run locally.
