### PR TITLE
fix(context-fetcher): never report an all-clear from a truncated or failed snapshot

### DIFF
--- a/v4/packages/kubeintellect-server/app/agent/nodes/context_fetcher.py
+++ b/v4/packages/kubeintellect-server/app/agent/nodes/context_fetcher.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 import os
 import subprocess
 import time
@@ -15,6 +16,45 @@ logger = get_logger(__name__)
 
 _SNAPSHOT_MAX_CHARS = 8_000
 
+# Notes appended to the snapshot when a listing was cut short or never
+# arrived. Mirrors the truncation marker in tools/kubectl_tool.py: the LLM
+# must be told the list it is looking at is incomplete, never left to infer
+# an all-clear from partial data.
+_SNAPSHOT_TRUNCATED_NOTE = (
+    "[snapshot truncated: output exceeded 8 000 chars and was cut short — "
+    "this listing is incomplete and may hide unhealthy pods or warning "
+    "events. Narrow the scope with -n <namespace> or -l <label>.]"
+)
+_SNAPSHOT_UNAVAILABLE_NOTE = (
+    "[snapshot unavailable: kubectl could not fetch this listing — "
+    "treat the cluster state as unknown, not healthy.]"
+)
+
+
+@dataclass(frozen=True)
+class SnapshotOutput:
+    """One capped kubectl snapshot listing, plus flags that say whether an
+    all-clear derived from it can be trusted.
+
+    ``truncated``   — the output hit the 8 000-char cap, so rows beyond the
+        cut are unknown.
+    ``unavailable`` — kubectl could not be run at all (missing binary,
+        timeout, bad kubeconfig), so nothing was fetched.
+    """
+
+    text: str
+    truncated: bool = False
+    unavailable: bool = False
+
+    def with_note(self) -> str:
+        """The capped text with a visible note appended when it is incomplete."""
+        if self.unavailable:
+            return f"{self.text}\n\n{_SNAPSHOT_UNAVAILABLE_NOTE}"
+        if self.truncated:
+            return f"{self.text}\n\n{_SNAPSHOT_TRUNCATED_NOTE}"
+        return self.text
+
+
 # Pod phases that count as "healthy" — anything else flips snapshot_has_issues.
 # (Note: STATUS column from `kubectl get pods` mixes phases and reasons —
 #  e.g. "CrashLoopBackOff", "ImagePullBackOff". We treat any value not in this
@@ -22,14 +62,27 @@ _SNAPSHOT_MAX_CHARS = 8_000
 _HEALTHY_POD_STATUSES = frozenset({"Running", "Completed", "Succeeded"})
 
 
-def _scan_snapshot(pods_out: str, events_out: str) -> tuple[bool, bool, int]:
+def _scan_snapshot(
+    pods_out: str,
+    events_out: str,
+    *,
+    pods_truncated: bool = False,
+    pods_unavailable: bool = False,
+    events_truncated: bool = False,
+    events_unavailable: bool = False,
+) -> tuple[bool, bool, int]:
     """Return (has_issues, has_warnings, pod_count) by scanning kubectl output.
 
     Cheap line-based parse — no extra subprocess calls. The pod table format is:
         NAMESPACE   NAME   READY   STATUS   RESTARTS   AGE
     We index the STATUS column by header position to be robust to column widths.
+
+    The ``*_truncated`` / ``*_unavailable`` flags are conservative guards: a
+    listing that was cut short (or never fetched) must not be reported as
+    clean, because an unhealthy pod or warning event may sit beyond the cap.
+    Callers derive them from SnapshotOutput.
     """
-    has_issues = False
+    has_issues = pods_truncated or pods_unavailable
     pod_count = 0
 
     lines = pods_out.splitlines()
@@ -53,11 +106,19 @@ def _scan_snapshot(pods_out: str, events_out: str) -> tuple[bool, bool, int]:
         if status not in _HEALTHY_POD_STATUSES:
             has_issues = True
 
-    has_warnings = bool(events_out.strip()) and "No resources found" not in events_out
+    has_warnings = events_truncated or events_unavailable
+    if events_out.strip() and "No resources found" not in events_out:
+        has_warnings = True
     return has_issues, has_warnings, pod_count
 
 
-def _run_kubectl_snapshot(args: list[str]) -> str:
+def _run_kubectl_snapshot(args: list[str]) -> SnapshotOutput:
+    """Run a kubectl snapshot query, capping output at _SNAPSHOT_MAX_CHARS.
+
+    Returns a SnapshotOutput carrying the capped text plus ``truncated`` /
+    ``unavailable`` flags so callers never mistake a partial or failed
+    listing for an all-clear signal.
+    """
     kubeconfig = os.path.expanduser(settings.KUBECONFIG_PATH)
     env = {**os.environ, "KUBECONFIG": kubeconfig}
     try:
@@ -70,10 +131,13 @@ def _run_kubectl_snapshot(args: list[str]) -> str:
             shell=False,
         )
         out = proc.stdout or proc.stderr or ""
-        return out[:_SNAPSHOT_MAX_CHARS]
+        return SnapshotOutput(
+            text=out[:_SNAPSHOT_MAX_CHARS],
+            truncated=len(out) > _SNAPSHOT_MAX_CHARS,
+        )
     except Exception as exc:
         logger.warning(f"context_fetcher: kubectl {' '.join(args[:2])} failed: {exc}")
-        return f"(unavailable: {exc})"
+        return SnapshotOutput(text=f"(unavailable: {exc})", unavailable=True)
 
 
 async def context_fetcher(state: AgentState) -> dict:
@@ -85,7 +149,7 @@ async def context_fetcher(state: AgentState) -> dict:
         session_id=session_id,
     ))
 
-    pods_out, events_out = await asyncio.gather(
+    pods, events = await asyncio.gather(
         asyncio.to_thread(_run_kubectl_snapshot, ["get", "pods", "--all-namespaces"]),
         asyncio.to_thread(_run_kubectl_snapshot, [
             "get", "events", "--all-namespaces",
@@ -95,25 +159,35 @@ async def context_fetcher(state: AgentState) -> dict:
     )
 
     parts = ["## Cluster Snapshot"]
-    parts.append(f"### Live Pod State\n```\n{pods_out.strip()}\n```")
+    pod_block = pods.with_note().strip() or "(no pods found)"
+    parts.append(f"### Live Pod State\n```\n{pod_block}\n```")
 
-    no_events = not events_out.strip() or "No resources found" in events_out
-    if no_events:
+    no_events = not events.text.strip() or "No resources found" in events.text
+    if events.unavailable:
+        parts.append(f"### Warning Events\n{events.with_note().strip()}")
+    elif no_events:
         parts.append("### Warning Events\n(none — cluster appears healthy)")
     else:
-        parts.append(f"### Warning Events (most recent)\n```\n{events_out.strip()}\n```")
+        parts.append(f"### Warning Events (most recent)\n```\n{events.with_note().strip()}\n```")
 
     cluster_snapshot = "\n\n".join(parts)
 
     # ── Snapshot health scan ──────────────────────────────────────────────────
-    has_issues, has_warnings, pod_count = _scan_snapshot(pods_out, events_out)
+    has_issues, has_warnings, pod_count = _scan_snapshot(
+        pods.text,
+        events.text,
+        pods_truncated=pods.truncated,
+        pods_unavailable=pods.unavailable,
+        events_truncated=events.truncated,
+        events_unavailable=events.unavailable,
+    )
 
     # ── Playbook trigger matching ─────────────────────────────────────────────
     matched_playbooks: list[str] = []
     if settings.PLAYBOOKS_ENABLED:
         try:
             from app.agent.playbooks import match_playbooks
-            matched_playbooks = match_playbooks(pods_out, events_out)
+            matched_playbooks = match_playbooks(pods.text, events.text)
         except Exception as exc:
             logger.warning(f"context_fetcher: playbook matching failed: {exc}")
 
@@ -133,6 +207,8 @@ async def context_fetcher(state: AgentState) -> dict:
             "snapshot_pod_count": pod_count,
             "snapshot_has_issues": has_issues,
             "snapshot_has_warnings": has_warnings,
+            "snapshot_truncated": pods.truncated or events.truncated,
+            "snapshot_unavailable": pods.unavailable or events.unavailable,
             "matched_playbooks": matched_playbooks,
             "cluster_id": cluster_id,
         },

--- a/v4/packages/kubeintellect-server/app/agent/nodes/coordinator.py
+++ b/v4/packages/kubeintellect-server/app/agent/nodes/coordinator.py
@@ -950,7 +950,7 @@ def _wait_for_rollout(namespace: str, max_wait_s: int = 30, poll_interval_s: flo
     while time.monotonic() < deadline:
         pods_out = _run_kubectl_snapshot(["get", "pods", "-n", namespace, "--no-headers"])
         in_transition = False
-        for line in pods_out.splitlines():
+        for line in pods_out.text.splitlines():
             cols = line.split()
             if len(cols) < 3:
                 continue
@@ -991,13 +991,20 @@ def _verify_resolution(namespace: str | None, pre_state: dict | None = None) -> 
             _wait_for_rollout(namespace)
 
         ns_arg = ["-n", namespace] if namespace else ["--all-namespaces"]
-        pods_out = _run_kubectl_snapshot(["get", "pods", *ns_arg])
-        events_out = _run_kubectl_snapshot([
+        pods = _run_kubectl_snapshot(["get", "pods", *ns_arg])
+        events = _run_kubectl_snapshot([
             "get", "events", *ns_arg,
             "--sort-by=.lastTimestamp",
             "--field-selector=type=Warning",
         ])
-        has_issues, has_warnings, _ = _scan_snapshot(pods_out, events_out)
+        has_issues, has_warnings, _ = _scan_snapshot(
+            pods.text,
+            events.text,
+            pods_truncated=pods.truncated,
+            pods_unavailable=pods.unavailable,
+            events_truncated=events.truncated,
+            events_unavailable=events.unavailable,
+        )
 
         if not has_issues:
             # Pods are healthy — even if old warning events linger, the fix

--- a/v4/packages/kubeintellect-server/app/agent/workflow.py
+++ b/v4/packages/kubeintellect-server/app/agent/workflow.py
@@ -90,7 +90,7 @@ async def targeted_investigator(state: AgentState) -> dict:
         session_id=session_id,
     ))
 
-    describe_out, events_out, deploy_out = await asyncio.gather(
+    describe, events, deployments = await asyncio.gather(
         asyncio.to_thread(_run_kubectl_snapshot, ["describe", "pod", pod, "-n", ns]),
         asyncio.to_thread(_run_kubectl_snapshot, ["get", "events", "-n", ns, "--sort-by=.lastTimestamp"]),
         asyncio.to_thread(_run_kubectl_snapshot, ["get", "deployments", "-n", ns]),
@@ -99,9 +99,9 @@ async def targeted_investigator(state: AgentState) -> dict:
     detail = (
         f"## Targeted Investigation: {pod} in {ns}\n"
         f"**Issue**: {issue}\n\n"
-        f"### Pod Description\n```\n{describe_out}\n```\n\n"
-        f"### Namespace Events\n```\n{events_out}\n```\n\n"
-        f"### Deployments\n```\n{deploy_out}\n```"
+        f"### Pod Description\n```\n{describe.with_note()}\n```\n\n"
+        f"### Namespace Events\n```\n{events.with_note()}\n```\n\n"
+        f"### Deployments\n```\n{deployments.with_note()}\n```"
     )
 
     existing = state.get("cluster_snapshot", "")

--- a/v4/tests/test_context_fetcher.py
+++ b/v4/tests/test_context_fetcher.py
@@ -1,7 +1,13 @@
 """Unit tests for the context_fetcher snapshot scan (C2)."""
 from __future__ import annotations
 
-from app.agent.nodes.context_fetcher import _scan_snapshot
+import subprocess
+
+from app.agent.nodes.context_fetcher import (
+    _SNAPSHOT_MAX_CHARS,
+    _run_kubectl_snapshot,
+    _scan_snapshot,
+)
 
 HEALTHY_PODS = """\
 NAMESPACE     NAME                              READY   STATUS    RESTARTS   AGE
@@ -67,3 +73,77 @@ def test_scan_handles_empty_pod_list() -> None:
     assert has_issues is False
     assert has_warnings is False
     assert pod_count == 0
+
+
+def test_scan_truncated_pod_list_is_not_clean() -> None:
+    # A truncated listing may hide an unhealthy pod past the cap — the
+    # all-clear signal must not survive truncation.
+    has_issues, has_warnings, pod_count = _scan_snapshot(
+        HEALTHY_PODS, NO_EVENTS, pods_truncated=True
+    )
+    assert has_issues is True
+    assert has_warnings is False
+    assert pod_count == 3  # visible rows are still counted
+
+
+def test_scan_unavailable_pod_list_is_not_clean() -> None:
+    has_issues, _, pod_count = _scan_snapshot(
+        "(unavailable: boom)", NO_EVENTS, pods_unavailable=True
+    )
+    assert has_issues is True
+    assert pod_count == 0
+
+
+def test_scan_truncated_events_are_not_clean() -> None:
+    _, has_warnings, _ = _scan_snapshot(
+        HEALTHY_PODS, NO_EVENTS, events_truncated=True
+    )
+    assert has_warnings is True
+
+
+def test_scan_unavailable_events_are_not_clean() -> None:
+    _, has_warnings, _ = _scan_snapshot(
+        HEALTHY_PODS, NO_EVENTS, events_unavailable=True
+    )
+    assert has_warnings is True
+
+
+def test_scan_full_healthy_snapshot_stays_clean() -> None:
+    # The conservative flags must not fire when nothing was truncated or lost.
+    has_issues, has_warnings, pod_count = _scan_snapshot(HEALTHY_PODS, NO_EVENTS)
+    assert has_issues is False
+    assert has_warnings is False
+    assert pod_count == 3
+
+
+class _FakeCompletedProcess:
+    def __init__(self, stdout: str, stderr: str = "") -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_snapshot_cap_marks_truncation(monkeypatch) -> None:
+    long_out = "NAMESPACE NAME READY STATUS RESTARTS AGE\n" + (
+        "default app-1 1/1 Running 0 2h\n" * 1000
+    )
+    assert len(long_out) > _SNAPSHOT_MAX_CHARS
+
+    def fake_run(*args: object, **kwargs: object) -> _FakeCompletedProcess:
+        return _FakeCompletedProcess(stdout=long_out)
+
+    monkeypatch.setattr("app.agent.nodes.context_fetcher.subprocess.run", fake_run)
+    result = _run_kubectl_snapshot(["get", "pods", "--all-namespaces"])
+    assert result.truncated is True
+    assert result.unavailable is False
+    assert result.text == long_out[:_SNAPSHOT_MAX_CHARS]
+
+
+def test_snapshot_failure_marks_unavailable(monkeypatch) -> None:
+    def fake_run(*args: object, **kwargs: object) -> _FakeCompletedProcess:
+        raise subprocess.TimeoutExpired(cmd=["kubectl"], timeout=5)
+
+    monkeypatch.setattr("app.agent.nodes.context_fetcher.subprocess.run", fake_run)
+    result = _run_kubectl_snapshot(["get", "pods"])
+    assert result.unavailable is True
+    assert result.truncated is False
+    assert "(unavailable:" in result.text


### PR DESCRIPTION
## What & why

Closes #140

The snapshot health flags (`snapshot_has_issues` / `snapshot_has_warnings`) were derived from kubectl output that had already been hard-capped at 8 000 chars — no marker, and no awareness that the cap had been hit. On a cluster with enough pods to overflow the cap, an unhealthy pod past the cut was invisible to both the scan and the LLM, so the coordinator could report the cluster as clean when it wasn't. A kubectl failure did the same for the pod listing (zero pods parsed → no issues).

- `_run_kubectl_snapshot` now returns a small `SnapshotOutput` (text + `truncated` / `unavailable` flags) instead of a bare string.
- `_scan_snapshot` treats truncated/unavailable listings conservatively — no all-clear from partial or failed data.
- The snapshot text the LLM sees carries an explicit note when a listing was cut short or never arrived (mirrors the existing marker in `run_kubectl`).
- `coordinator._verify_resolution` inherits the same conservatism, so a fix is no longer marked "resolved" from a partial listing.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / chore
- [ ] Performance
- [ ] Tests

## Scope

- Version directory touched: v4/
- [x] This change is scoped to a version whose contributions are open (`v4/`, or docs/typos in older versions).

## Checklist

- [x] New behavior has both a **happy-path** and an **error-path** test (`tests/test_context_fetcher.py`)
- [x] No mutating ops touched — the HITL/RBAC invariants are unaffected
- [x] Secret values are never logged or returned (n/a here)
- [x] `uv run pytest` passes locally — see gate output below
- [x] `uv run ruff check` passes locally
- [x] `uv run mypy` passes locally — 171 source files, 0 errors
- [x] Docs updated if behavior/CLI/flags changed — n/a, no user-facing behavior change

## Notes for reviewers

Gates run (all from `v4/`):

- `uv run ruff check packages/kubeintellect-server/app/ packages/ki-protocol/` — clean
- `uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube-q/kube_q` — 0 errors (171 source files)
- `uv run python -m pytest tests/ -q` — 1027 passed under `PYTHONUTF8=1`

One environment note: on my Windows box (GBK locale, code page 936) the default-locale run shows 46 failures in `tests/test_playbooks.py`. That is the pre-existing playbook loader encoding bug tracked in #136 — the loader uses `path.read_text()` without an explicit encoding, so only 2 of the playbooks load under a non-UTF-8 locale. It is unrelated to this change and green under a UTF-8 locale, which is what CI runs.

Heads-up: I used AI assistance to help draft and verify this change — happy to walk through any part of it in review.