### PR TITLE
feat(helm): claim Verified Publisher on Artifact Hub

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -141,6 +141,26 @@ jobs:
         run: |
           helm show chart "${OCI_REPO}/kubeintellect" --version "${{ steps.version.outputs.version }}"
 
+      # Earns the "Verified Publisher" label on Artifact Hub by proving that
+      # whoever controls this registry namespace also registered the repository
+      # there. It is a sibling OCI artifact tagged `artifacthub.io`, not part of
+      # the chart, so it is pushed separately with oras.
+      - name: Publish the Artifact Hub repository metadata
+        env:
+          ORAS_VERSION: 1.3.3
+        run: |
+          curl -fsSL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" \
+            | tar -xz -C /tmp oras
+          /tmp/oras version
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | /tmp/oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+          # Push from inside the chart directory so the layer is titled
+          # `artifacthub-repo.yml` rather than its full repo-relative path.
+          cd "${CHART_DIR}"
+          /tmp/oras push "ghcr.io/mskazemi/charts/kubeintellect:artifacthub.io" \
+            --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+            "artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml"
+
       - name: Summary
         run: |
           {

--- a/v4/deploy/helm/kubeintellect/.helmignore
+++ b/v4/deploy/helm/kubeintellect/.helmignore
@@ -1,0 +1,10 @@
+# Artifact Hub repository metadata is pushed as its own OCI artifact by
+# .github/workflows/helm-publish.yml — it is not part of the chart.
+artifacthub-repo.yml
+
+# Per-cloud examples are documentation, not chart input.
+*.yaml.example
+
+.DS_Store
+.git/
+*.tgz

--- a/v4/deploy/helm/kubeintellect/artifacthub-repo.yml
+++ b/v4/deploy/helm/kubeintellect/artifacthub-repo.yml
@@ -1,0 +1,15 @@
+# Artifact Hub repository metadata.
+#
+# Publishing this file alongside the chart in the OCI registry is what earns the
+# "Verified Publisher" label on https://artifacthub.io/packages/helm/kubeintellect/kubeintellect
+# — it proves whoever controls the registry is the same person who registered
+# the repository on Artifact Hub.
+#
+# It is pushed as a separate OCI artifact tagged `artifacthub.io` by
+# .github/workflows/helm-publish.yml; it is NOT part of the chart itself.
+#
+# repositoryID comes from the Artifact Hub control panel and is not a secret.
+repositoryID: 38553280-cd24-4ff0-bc0f-f23ee642faac
+owners:
+  - name: Mohsen Seyedkazemi Ardebili
+    email: mohsen.seyedkazemi@gmail.com


### PR DESCRIPTION
The chart went live at https://artifacthub.io/packages/helm/kubeintellect/kubeintellect today (v2.2.0), but shows `verified_publisher: false`.

Artifact Hub grants that label when the registry itself serves a metadata file carrying the repository ID — it proves whoever controls the namespace is the same person who registered the repository there.

For an OCI repository that file is a **sibling artifact tagged `artifacthub.io`**, not part of the chart, so `helm-publish.yml` pushes it with `oras` right after the chart. A `.helmignore` keeps it (and the per-cloud `*.yaml.example` docs) out of the chart tarball — verified locally that the packaged `.tgz` no longer contains either.

The repository ID is not a secret.