### PR TITLE
fix(helm): correct the Artifact Hub repositoryID

### DIFF
--- a/v4/deploy/helm/kubeintellect/artifacthub-repo.yml
+++ b/v4/deploy/helm/kubeintellect/artifacthub-repo.yml
@@ -9,7 +9,12 @@
 # .github/workflows/helm-publish.yml; it is NOT part of the chart itself.
 #
 # repositoryID comes from the Artifact Hub control panel and is not a secret.
-repositoryID: 38553280-cd24-4ff0-bc0f-f23ee642faac
+# Read it from the API, not the control-panel screen — the two are the same
+# value, but a mistyped character fails silently: Artifact Hub simply leaves
+# verified_publisher false with no error anywhere.
+#   curl -s https://artifacthub.io/api/v1/packages/helm/kubeintellect/kubeintellect \
+#     | python3 -c 'import sys,json;print(json.load(sys.stdin)["repository"]["repository_id"])'
+repositoryID: 38553280-cd24-4ff4-bc0f-f23ee642faac
 owners:
   - name: Mohsen Seyedkazemi Ardebili
     email: mohsen.seyedkazemi@gmail.com


### PR DESCRIPTION
The repositoryID in `artifacthub-repo.yml` was written as `…-4ff0-…` where the real value is `…-4ff4-…`, so Artifact Hub could not match the metadata artifact to the repository and left `verified_publisher: false`.

**This fails completely silently** — no error on the package page, in the control panel, or in the publish workflow. The badge simply never appears. Confirmed by polling the API for 30 minutes after the metadata artifact was pushed successfully.

The value is now taken from the API, and the file records the one-liner to re-read it so the next person does not transcribe it by eye.