### PR TITLE
fix(krew): indent the manifest to the form addURIAndSha expects

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -48,47 +48,47 @@ spec:
 
     Documentation: https://mskazemi.github.io/kubeintellect/
   platforms:
-    - selector:
-        matchLabels:
-          os: linux
-          arch: amd64
-      {{addURIAndSha "https://github.com/MSKazemi/kubeintellect/releases/download/{{ .TagName }}/kq_linux_amd64.tar.gz" .TagName }}
-      bin: kq
-      files:
-        - from: kq
-          to: .
-        - from: LICENSE
-          to: .
-    - selector:
-        matchLabels:
-          os: linux
-          arch: arm64
-      {{addURIAndSha "https://github.com/MSKazemi/kubeintellect/releases/download/{{ .TagName }}/kq_linux_arm64.tar.gz" .TagName }}
-      bin: kq
-      files:
-        - from: kq
-          to: .
-        - from: LICENSE
-          to: .
-    - selector:
-        matchLabels:
-          os: darwin
-          arch: amd64
-      {{addURIAndSha "https://github.com/MSKazemi/kubeintellect/releases/download/{{ .TagName }}/kq_darwin_amd64.tar.gz" .TagName }}
-      bin: kq
-      files:
-        - from: kq
-          to: .
-        - from: LICENSE
-          to: .
-    - selector:
-        matchLabels:
-          os: darwin
-          arch: arm64
-      {{addURIAndSha "https://github.com/MSKazemi/kubeintellect/releases/download/{{ .TagName }}/kq_darwin_arm64.tar.gz" .TagName }}
-      bin: kq
-      files:
-        - from: kq
-          to: .
-        - from: LICENSE
-          to: .
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    {{addURIAndSha "https://github.com/MSKazemi/kubeintellect/releases/download/{{ .TagName }}/kq_linux_amd64.tar.gz" .TagName }}
+    bin: kq
+    files:
+    - from: kq
+      to: .
+    - from: LICENSE
+      to: .
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    {{addURIAndSha "https://github.com/MSKazemi/kubeintellect/releases/download/{{ .TagName }}/kq_linux_arm64.tar.gz" .TagName }}
+    bin: kq
+    files:
+    - from: kq
+      to: .
+    - from: LICENSE
+      to: .
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    {{addURIAndSha "https://github.com/MSKazemi/kubeintellect/releases/download/{{ .TagName }}/kq_darwin_amd64.tar.gz" .TagName }}
+    bin: kq
+    files:
+    - from: kq
+      to: .
+    - from: LICENSE
+      to: .
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/MSKazemi/kubeintellect/releases/download/{{ .TagName }}/kq_darwin_arm64.tar.gz" .TagName }}
+    bin: kq
+    files:
+    - from: kq
+      to: .
+    - from: LICENSE
+      to: .


### PR DESCRIPTION
krew-release-bot rejected the rendered manifest on the v2.3.0 release:

```
level=fatal msg="failed to get plugin name from processed template.
err: error converting YAML to JSON: yaml: line 55: did not find expected '-' indicator"
```

`addURIAndSha` emits its `sha256:` continuation line at a **hard-coded four-space indent**, so the template call itself has to sit at four spaces. Ours was nested two deeper, which put `uri:` at six and `sha256:` at four and made the mapping inconsistent.

Verified red-green by rendering the template with a stub `addURIAndSha`: the old file reproduces the bot's parse error exactly, the new one parses and yields all four platforms pointing at the right archives.

The release assets themselves are fine — `kq_linux_amd64.tar.gz` from v2.3.0 downloads, matches its checksum, and runs under `env -i`.