### PR TITLE
release: v2.3.1 — fix the krew manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.3.1] – 2026-08-15
+
+### Fixed
+- **The krew manifest could not be rendered**, so `kubectl kq` was never submitted to
+  `krew-index` on the v2.3.0 release. `addURIAndSha` emits its `sha256:` continuation line at a
+  hard-coded four-space indent, so the template call has to sit at four spaces itself; ours was
+  nested two deeper, which put `uri:` at six and `sha256:` at four and made the mapping
+  inconsistent — krew-release-bot failed with *"error converting YAML to JSON: yaml: line 55:
+  did not find expected '-' indicator"*. Reindented to the canonical form and checked by
+  rendering the template with a stub helper, which reproduces the failure on the old file and
+  parses on the new one. The v2.3.0 release assets themselves were fine.
+
+
 ## [2.3.0] – 2026-08-15
 
 ### Added

--- a/v4/deploy/helm/kubeintellect/Chart.yaml
+++ b/v4/deploy/helm/kubeintellect/Chart.yaml
@@ -7,8 +7,8 @@ type: application
 # and are both rewritten from the git tag by .github/workflows/helm-publish.yml,
 # so the values checked in here only matter for `helm install` straight from a
 # clone. Bump them by hand only for a chart-only change between releases.
-version: 2.3.0
-appVersion: "2.3.0"
+version: 2.3.1
+appVersion: "2.3.1"
 
 home: https://kubeintellect.com
 icon: https://raw.githubusercontent.com/MSKazemi/kubeintellect/main/v4/docs/assets/brand/ki-icon.svg

--- a/v4/packages/kubeintellect-server/pyproject.toml
+++ b/v4/packages/kubeintellect-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kubeintellect"
-version = "2.3.0"
+version = "2.3.1"
 description = "AI-powered Kubernetes management — local server and CLI"
 readme = "README.md"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
v2.3.0 shipped a `.krew.yaml` that krew-release-bot could not render, so `kubectl kq` never reached krew-index. The manifest fix landed in #148; krew reads the manifest from the **release ref**, so a re-run of the v2.3.0 event would still see the broken file. This cuts a patch release so the bot gets a fresh release event carrying the corrected manifest.

The v2.3.0 release assets were fine — `kq_linux_amd64.tar.gz` downloads, matches its checksum, and runs under `env -i`.