### PR TITLE
docs: add k3s adopter entry and fix kq cli query flag in README

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -17,7 +17,7 @@ yourself is the single lowest-effort, highest-value contribution to the project.
 
 | Organization / person | Since | Environment | How it's used | Contact |
 |---|---|---|---|---|
-| _(you could be here)_ | | | | |
+| [@ybayraktarb](https://github.com/ybayraktarb) | 2026-08 | k3s / k3d (macOS) | install path verification & evaluation | [@ybayraktarb](https://github.com/ybayraktarb) |
 
 **Columns**
 

--- a/v4/README.md
+++ b/v4/README.md
@@ -15,9 +15,9 @@
 Ask KubeIntellect a question in plain English — it queries kubectl, Prometheus, and Loki live, then answers. Destructive operations pause for your explicit approval before anything runs.
 
 ```bash
-kq "why is my api-server pod crashlooping?"
-kq "show me pods with high restart counts in the default namespace"
-kq "scale the frontend deployment to 5 replicas"   # pauses for your approval
+kq -q "why is my api-server pod crashlooping?"
+kq -q "show me pods with high restart counts in the default namespace"
+kq -q "scale the frontend deployment to 5 replicas"   # pauses for your approval
 ```
 
 > **Safe by default** — read-only queries run immediately; scale, delete, and restart operations require explicit human-in-the-loop approval.


### PR DESCRIPTION
## What & why

Verified the KubeIntellect install path against a k3s / k3d cluster on macOS as requested in #100. 
This PR:
1. Adds a verification entry for k3s / k3d to `ADOPTERS.md`.
2. Updates quickstart examples in `v4/README.md` to use the `-q` / `--query` flag required by the `kq` CLI for one-off questions.

Closes #100

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📖 Docs
- [ ] 🧹 Refactor / chore
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## Scope

- Version directory touched: `ADOPTERS.md`, `v4/README.md`
- [x] This change is scoped to a version whose contributions are open (`v4/`, or docs/typos in older versions).

## Checklist

- [ ] New behavior has both a **happy-path** and an **error-path** test
- [ ] **Adding a playbook?** `triggers:` and `detect:` are two independent features — a test proves
      the compiled `detect:` predicate **fires** on a realistic event and does **not** fire on a
      neighbouring one. The counts and the schema check prove neither. (`kind:` is the observation
      channel — `Pod` / `Event` / `Node` — never the Kubernetes object; use `involved_kind:` to
      narrow the subject.)
- [x] **Every mutating/write operation keeps its dry-run + diff + human-approval (HITL) gate** (safety invariant)
- [x] Secret values are never logged or returned (key names only)
- [x] `uv run pytest` passes locally (1023 server tests, 312 CLI tests)
- [x] `uv run ruff check .` passes locally (0 errors)
- [x] `uv run mypy src` passes locally (171 source files clean)
- [x] Docs updated if behavior/CLI/flags changed
<!-- Nothing to sign. No CLA, no DCO sign-off, no `git commit -s` — see LICENSING.md. -->

## Notes for reviewers

- Verified on a 2-node k3d cluster (`v1.35.5+k3s1`).
- All 6 repo gates (`make check-modes`, `make check-syntax`, `ruff check`, `mypy`, server & CLI pytests) passed locally.
- Full verification report with command outputs has been posted as a comment on #100.
