### PR TITLE
fix(ci): unbreak main after #133 + #138, and finish the triage repair loop

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -64,7 +64,8 @@
       "contributions": [
         "doc",
         "security",
-        "code"
+        "code",
+        "test"
       ]
     }
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ uv run ruff check packages/kubeintellect-server/app/ packages/ki-protocol/
 # 2. Types — the workspace is at ZERO errors; keep it there.
 uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube-q/kube_q
 
-# 3. Server suite (1040 tests)
+# 3. Server suite (1047 tests)
 uv run python -m pytest tests/ -q
 
 # 4. kq CLI suite (312 tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   instead of contradicting it.
 
 ### Fixed
+- **Every playbook silently failed to load on a non-UTF-8 locale** (#136, #138 — reported and
+  fixed by [@uuzzrm](https://github.com/uuzzrm)). The playbook loader read its YAML with a bare
+  `path.read_text()`, which decodes using the *platform default* encoding. On Windows
+  (CP1252/CP936) or under the POSIX `C` locale the em-dashes the playbooks contain raise
+  `UnicodeDecodeError` — and `_load_all()`'s per-file `except` swallowed it, so the server came
+  up with **zero** playbooks and nothing in the logs that looked like a failure. Now read
+  explicitly as UTF-8 in the v2, v3 and v4 loaders, each with a regression test that fails if the
+  encoding argument is ever dropped again.
+
+  ⚠️ CI runs the **v4 and kube-q suites only**, so the v2/v3 regression tests are not guarded by
+  CI. They were run by hand for this merge (v2 25 passed, v3 12 passed).
+
+- **A malformed triage reply silently discarded the user's request** (#22, #133 — contributed by
+  [@uuzzrm](https://github.com/uuzzrm)). The triage tier answers in strict JSON, and a reply that
+  did not parse was converted straight into `{"mode": "investigate", "plan": []}`. A user who
+  asked a *chat* question got a full cluster investigation instead, and nothing recorded that the
+  model's answer had been thrown away. The reply now goes back to the model with a corrective
+  hint, up to **3 attempts** total, before falling back to the investigate default.
+
+  Follow-up in the same seam: `_parse_triage_json_strict` now also rejects a `plan` that is not a
+  list. `triage()` does `(parsed.get("plan") or [])[:6]`, so a *string* plan sliced into six
+  single characters and emitted six one-character PlanSteps — pre-existing, and now sent back
+  through the repair loop instead. The echoed malformed reply is capped at 2 000 chars so a
+  pathological reply cannot be re-sent on every remaining attempt and exhaust the context window.
+
+### Fixed
 - **`v4/uv.lock` was stale — it still recorded `kubeintellect 2.2.0` after the 2.3.1 bump.**
   `uv lock --check` failed against the committed lockfile (rc=1, *"the lockfile needs to be
   updated"*), so `uv sync --locked` / `--frozen` — what a reproducible release build should use —

--- a/v4/packages/kubeintellect-server/app/cortex/graph.py
+++ b/v4/packages/kubeintellect-server/app/cortex/graph.py
@@ -108,6 +108,7 @@ calls — answer only."""
 # reply does not parse, we feed it back with a corrective hint and retry before
 # falling back to the investigate default.
 _TRIAGE_MAX_PARSE_ATTEMPTS = 3
+_TRIAGE_REPAIR_ECHO_MAX_CHARS = 2_000
 _TRIAGE_REPAIR_HINT = (
     "Your previous response was not valid triage JSON. Reply with ONLY a JSON "
     'object matching the schema: {"mode": "chat" | "investigate", '
@@ -192,7 +193,10 @@ async def _triage_with_repair(
         )
         prompt = [
             *prompt,
-            AIMessage(content=str(reply.content)),
+            # Echo back only enough of the bad reply to make the correction
+            # concrete. Unbounded, a pathological reply would be re-sent on
+            # every remaining attempt and could exhaust the context window.
+            AIMessage(content=str(reply.content)[:_TRIAGE_REPAIR_ECHO_MAX_CHARS]),
             HumanMessage(content=_TRIAGE_REPAIR_HINT),
         ]
     logger.warning(
@@ -530,9 +534,17 @@ _JSON_RE = re.compile(r"\{.*\}", re.DOTALL)
 
 def _parse_triage_json_strict(text: str) -> dict | None:
     """Parse a triage reply into a validated plan dict, or None when the
-    reply is not usable triage JSON (no JSON block, malformed JSON, or an
-    unrecognised mode). The repair loop uses this to tell "bad reply" apart
-    from "investigate" as a deliberate answer."""
+    reply is not usable triage JSON (no JSON block, malformed JSON, an
+    unrecognised mode, or a `plan` that is not a list). The repair loop uses
+    this to tell "bad reply" apart from "investigate" as a deliberate answer.
+
+    `plan` is type-checked here rather than at the call site because that is
+    where a bad value does its damage: `triage` does
+    `(parsed.get("plan") or [])[:6]`, so a *string* plan slices into six
+    single characters and emits six one-character PlanSteps. Returning None
+    instead sends it back through the repair loop, which is what the caller
+    wants for every other malformed field.
+    """
     match = _JSON_RE.search(text)
     if not match:
         return None
@@ -542,13 +554,10 @@ def _parse_triage_json_strict(text: str) -> dict | None:
         return None
     if not isinstance(data, dict) or data.get("mode") not in ("chat", "investigate"):
         return None
+    plan = data.get("plan")
+    if plan is not None and not isinstance(plan, list):
+        return None
     return data
-
-
-def _parse_triage_json(text: str) -> dict:
-    """Parse a triage reply, falling back to investigate on failure (kept
-    for callers that want the old lenient behaviour)."""
-    return _parse_triage_json_strict(text) or {"mode": "investigate", "plan": []}
 
 
 def _last_user_text(state) -> str:

--- a/v4/tests/test_cortex.py
+++ b/v4/tests/test_cortex.py
@@ -27,18 +27,28 @@ def _state(**over):
 
 class TestTriageParsing:
     def test_valid_json(self):
-        parsed = cx._parse_triage_json('{"mode": "chat", "plan": []}')
+        parsed = cx._parse_triage_json_strict('{"mode": "chat", "plan": []}')
+        assert parsed is not None
         assert parsed["mode"] == "chat"
 
     def test_json_embedded_in_prose(self):
-        parsed = cx._parse_triage_json(
+        parsed = cx._parse_triage_json_strict(
             'Sure! {"mode": "investigate", "plan": ["check pods"]} done'
         )
+        assert parsed is not None
         assert parsed["plan"] == ["check pods"]
 
-    def test_garbage_defaults_to_investigate(self):
-        assert cx._parse_triage_json("not json")["mode"] == "investigate"
-        assert cx._parse_triage_json('{"mode": "nonsense"}')["mode"] == "investigate"
+    def test_garbage_is_rejected_for_repair(self):
+        # The repair loop needs "unusable" to be distinguishable from a
+        # deliberate "investigate"; triage() supplies the fallback.
+        assert cx._parse_triage_json_strict("not json") is None
+        assert cx._parse_triage_json_strict('{"mode": "nonsense"}') is None
+
+    def test_non_list_plan_is_rejected(self):
+        # A string plan would otherwise slice into six one-character PlanSteps
+        # via (parsed.get("plan") or [])[:6] in triage().
+        assert cx._parse_triage_json_strict('{"mode": "chat", "plan": "do a thing"}') is None
+        assert cx._parse_triage_json_strict('{"mode": "chat"}') is not None
 
 
 class TestRouting:
@@ -250,6 +260,30 @@ class TestTriageRetry:
 
         assert out["triage_mode"] == "investigate"
         assert fake_llm.ainvoke.await_count == cx._TRIAGE_MAX_PARSE_ATTEMPTS
+
+    async def test_repair_echo_is_capped(self, mocker):
+        mocker.patch.object(cx, "emit")
+        huge = "x" * 50_000
+        sent_prompts = []
+        fake_llm = mocker.AsyncMock()
+
+        async def _ainvoke(prompt, config):
+            sent_prompts.append(prompt)
+            if len(sent_prompts) == 1:
+                return mocker.MagicMock(content=huge)
+            return mocker.MagicMock(content='{"mode": "chat", "plan": []}')
+
+        fake_llm.ainvoke = _ainvoke
+        mocker.patch("app.cortex.models.get_triage_llm", return_value=fake_llm)
+
+        await cx.triage(_state(), {})
+
+        echoed = [
+            m for m in sent_prompts[1]
+            if isinstance(m, AIMessage) and m.content.startswith("x")
+        ]
+        assert echoed, "the malformed reply was not echoed back"
+        assert len(echoed[0].content) == cx._TRIAGE_REPAIR_ECHO_MAX_CHARS
 
     def test_strict_parser_distinguishes_failure_from_valid(self):
         assert cx._parse_triage_json_strict("not json") is None


### PR DESCRIPTION
Main is red at `6c53804`: `Tests (server)`, `Tests (server · py3.13)` and `Tests (server · py3.14)` all fail on `test_doc_claims.py`.

## Why main went red

#133 and #138 were each green on their own head SHA. Both were branched 31 commits back and both added tests, so **neither run ever saw the other's**. The doc-claims gate compares `AGENTS.md`'s server-suite count against a live collect — it claimed 1040, the merged tree collects 1047.

This is the count-drift trap again, in a new place: a per-PR gate cannot see a number that only two merges *together* move. Worth a follow-up — the check belongs on `main` after merge, not only on the PR.

## What is here

**`d93a9fd` — finish the triage repair loop** (fix-on-top of @uuzzrm's #133, in the seam that PR created)

- `_parse_triage_json` had no production caller left once the repair loop landed, and its docstring claimed it was *"kept for callers that want the old lenient behaviour"* — there were none. Removed; the four existing parsing tests now assert against `_parse_triage_json_strict` directly.
- The strict parser validated `mode` but not `plan`. `triage()` does `(parsed.get("plan") or [])[:6]`, so a **string** plan sliced into six single characters and emitted six one-character PlanSteps. Pre-existing — the old lenient parser was equally lax — but this is the right place to fix it, and rejecting it sends the reply back through the repair loop, which is what the loop is for.
- The malformed reply was echoed into the retry prompt verbatim; capped at 2 000 chars so a pathological reply cannot be re-sent on every remaining attempt and exhaust the context window.

**`5974c1b` — unbreak main + docs + credit**

- `AGENTS.md` server-suite count 1040 → 1047 (kq CLI stays 312, still correct).
- CHANGELOG entries for #136/#138 and #22/#133, crediting @uuzzrm inline, plus the note that CI does not cover the v2/v3 suites those regression tests live in.
- `.all-contributorsrc`: `test` added to @uuzzrm — both PRs arrived with real regression tests, which is the part that made them mergeable.

## Verification

Red-green: reverting the plan check fails `test_non_list_plan_is_rejected`; reverting the cap fails `test_repair_echo_is_capped`; nothing else moves.

| gate | result |
|---|---|
| ruff | clean |
| mypy | 0 errors / 172 files |
| server suite | 1047 passed |
| kq CLI suite | 312 passed |
| file modes | rc=0 |
| syntax warnings | rc=0 |
| doc-claims | 2 passed |

## Follow-ups (not in this PR)

- Count-drift gates run per-PR and cannot see cross-PR drift — run doc-claims on `main` after merge.
- CI does not run the v2/v3 suites, so #138's regression tests there are unguarded.
- `read_text()`/`open()` without `encoding=` in ~25 more places: `cli.py` config reads/writes, `kube_q/cli/repl.py:99,121` (`.env`), `kube_q/core/session.py:90,95,100`.
- Issue #136 carries no labels.