### PR TITLE
ci: gate the demo front-end (lint + build) — the tree CI never looked at

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,3 +286,39 @@ jobs:
 
       - name: Server package imports
         run: /tmp/smoke/bin/python -c "import app; print('kubeintellect server import OK')"
+
+  web:
+    name: Web (lint + build)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: v4/packages/kube-q/web
+    # The demo front-end had NO gate of any kind until now, and the gap was not
+    # theoretical: PR #142 (eslint 9 -> 10) reported all 15 checks green while
+    # `npm run lint` died with `contextOrFilename.getFilename is not a function`
+    # — eslint 10 dropped the legacy rule-context API that eslint-plugin-react,
+    # vendored inside eslint-config-next, still calls. Every Python gate passed
+    # because not one of them looks at this directory.
+    #
+    # `npm ci` (not `npm install`) is the point of the install step: it fails
+    # when package.json and package-lock.json disagree, which is exactly what a
+    # hand-merged or stale lockfile looks like. npm resolved that eslint bump by
+    # OVERRIDING a peer dependency it could not satisfy and warning rather than
+    # failing, so the install succeeding is not on its own evidence of anything.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: v4/packages/kube-q/web/package-lock.json
+
+      - name: Install (lockfile must match the manifest)
+        run: npm ci --no-audit --no-fund
+
+      - name: eslint
+        run: npm run lint
+
+      - name: next build
+        run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   *tolerable risk* with that justification, so the security tab now reflects the written policy
   instead of contradicting it.
 
+### Added
+- **CI now gates the demo front-end** (`Web (lint + build)`). `v4/packages/kube-q/web` had no
+  gate of any kind: every existing job is scoped to the Python tree, so nothing in CI had ever
+  run `npm ci`, `eslint` or `next build`. The gap was not theoretical — the eslint 9 → 10 bump
+  (#142) reported **all 15 checks green** while `npm run lint` failed outright with
+  `contextOrFilename.getFilename is not a function`, because eslint 10 removed the legacy
+  rule-context API that `eslint-plugin-react` (vendored inside `eslint-config-next@16.3.0`)
+  still calls. The job runs `npm ci` rather than `npm install` so a lockfile that disagrees with
+  the manifest fails instead of being silently re-resolved.
+
 ### Fixed
 - **The documented one-shot query form had never worked, and a failed one exited 0** (#151,
   reported by [@ybayraktarb](https://github.com/ybayraktarb) while verifying the install path on


### PR DESCRIPTION
## Why

`v4/packages/kube-q/web` had **no CI gate of any kind**. Every job in `ci.yml` is scoped to the Python tree, so a change could break the web app's lint *and* its build and still show a full row of green checks.

That is exactly how it presented. #142 (eslint 9 → 10) reported **all 15 checks green** while `npm run lint` exited 2:

```
TypeError: Error while loading rule 'react/display-name':
contextOrFilename.getFilename is not a function
```

eslint 10 removed the legacy rule-context API, and `eslint-plugin-react` — vendored inside `eslint-config-next@16.3.0` — still calls it.

npm had actually detected the incompatibility and declined to act on it: `eslint-plugin-import` declares a peer range ending at `^9`, so npm **overrode** the peer dependency and warned rather than failing:

```
npm warn Conflicting peer dependency: eslint@9.39.5
```

So a successful install is not on its own evidence that the tree works.

## What

One job, `Web (lint + build)`:

- `npm ci` (**not** `npm install`) — fails when `package.json` and `package-lock.json` disagree, which is the shape a stale or hand-merged lockfile takes.
- `npm run lint`
- `npm run build`

## Verification

Run in a clean worktree, both directions — the discrimination is the point:

| Tree | `npm ci` | `eslint` | `next build` |
|---|---|---|---|
| this branch (`main` + #141) | 0 | 0 | 0 |
| #142 head (`0862d9e`) | 0 | **2** | not reached |

## Note

Deliberately **not** added to branch protection's required contexts here — that is a repo-settings change worth making once the job has a history of runs.

I did not add a Dependabot `ignore` for eslint majors. A pinned linter is how this repo already acquired one permanent blind spot (`ruff<0.16`, which is why `File modes` has to exist as a separate dependency-free gate); a second one is the wrong trade. A gate that runs is better than a bump that never arrives.