### PR TITLE
fix(docker): the published image could not start — builder and runtime disagreed on Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,3 +286,58 @@ jobs:
 
       - name: Server package imports
         run: /tmp/smoke/bin/python -c "import app; print('kubeintellect server import OK')"
+
+  image:
+    name: Container image (build + serve)
+    runs-on: ubuntu-latest
+    # The image was built and published on every release without ever being
+    # started. It could not start: the builder stage produced a 3.12 venv, the
+    # runtime stage shipped a 3.13 interpreter, and a venv's site-packages path
+    # is version-stamped — so sys.path carried no site-packages at all and
+    # `docker run <image>` died on "No module named uvicorn". Every gate was
+    # green throughout, because a `docker build` that succeeds proves only that
+    # the layers assembled.
+    #
+    # The Dockerfile now asserts the venv matches the interpreter at build time,
+    # which protects the publish workflow too. This job adds the part an
+    # assertion cannot cover: that the thing actually serves a request.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Build image
+        run: docker build -t kubeintellect:ci v4
+
+      - name: Start Postgres
+        run: |
+          docker network create kinet
+          docker run -d --name kipg --network kinet \
+            -e POSTGRES_DB=kubeintellect \
+            -e POSTGRES_USER=kubeintellect \
+            -e POSTGRES_PASSWORD=password \
+            postgres:16-alpine
+          for _ in $(seq 1 30); do
+            docker exec kipg pg_isready -U kubeintellect >/dev/null 2>&1 && exit 0
+            sleep 1
+          done
+          echo "Postgres did not become ready" >&2; exit 1
+
+      # Credentials are deliberately bogus. Startup must not require a reachable
+      # model endpoint — only that configuration is present and the app boots.
+      - name: Run the image and probe /healthz
+        run: |
+          docker run -d --name kiapp --network kinet -p 8000:8000 \
+            -e AZURE_OPENAI_ENDPOINT=https://example.invalid \
+            -e AZURE_OPENAI_API_KEY=dummy \
+            -e OPENAI_API_KEY=dummy \
+            -e POSTGRES_HOST=kipg \
+            kubeintellect:ci
+          for _ in $(seq 1 45); do
+            if [ "$(curl -s -o /tmp/hz.json -w '%{http_code}' http://127.0.0.1:8000/healthz)" = "200" ]; then
+              echo "healthz: $(cat /tmp/hz.json)"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::the container never served /healthz"
+          docker logs kiapp 2>&1 | tail -40
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   instead of contradicting it.
 
 ### Fixed
+- **The published container image could not start.** `docker run` on any released image failed
+  immediately with `No module named uvicorn`, and it had been that way since the image was
+  introduced. The builder stage resolved dependencies on `uv:python3.12-bookworm-slim` while the
+  runtime stage ran `python:3.13-slim`. The venv is copied wholesale between them, but a venv's
+  packages live at the version-stamped `lib/python3.X/site-packages` and its `bin/python` is only
+  a symlink to `/usr/local/bin/python` — which resolves to the *runtime* interpreter. So Python
+  3.13 looked for `lib/python3.13/site-packages`, found only `lib/python3.12`, and started with
+  **no site-packages on `sys.path` at all**.
+
+  Nothing caught it because nothing ever ran the image. `docker-publish.yml` builds, pushes and
+  writes a summary; a `docker build` that succeeds proves only that the layers assembled. This is
+  the same shape as the `kubeintellect --version` regression that shipped to PyPI under a green
+  install-smoke job.
+
+  The builder is now `uv:python3.13-bookworm-slim`, matching the runtime. Two guards were added
+  so it cannot recur silently: the Dockerfile asserts at build time that the copied venv matches
+  the running interpreter and that `uvicorn`, `fastapi`, `pydantic_core` and `pydantic_settings`
+  import (this travels with the Dockerfile, so the publish path is covered too), and a new CI job
+  `Container image (build + serve)` starts the image against Postgres and requires a 200 from
+  `/healthz`.
+
+  Verified end to end: the fixed image returns
+  `{"status":"ok","arm":"v4",...}` and logs `Application startup complete`, where the previous
+  image fails to load its own entry point.
+
 - **The documented one-shot query form had never worked, and a failed one exited 0** (#151,
   reported by [@ybayraktarb](https://github.com/ybayraktarb) while verifying the install path on
   k3s/k3d for #100). `kq "question"` reads the first positional as a *subcommand*, so it printed

--- a/v4/Dockerfile
+++ b/v4/Dockerfile
@@ -16,7 +16,14 @@
 #   https://dl.k8s.io/release/stable.txt
 
 # ── Stage 1: Python dependency builder ────────────────────────────────────────
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+# This tag's Python minor version MUST match the runtime stage's below. The venv
+# produced here is copied wholesale into the runtime image, and a venv's
+# site-packages path is version-stamped (lib/python3.X/site-packages) while
+# bin/python is only a symlink to /usr/local/bin/python -- which resolves to
+# whatever interpreter the RUNTIME image ships. Build on 3.12, run on 3.13, and
+# the interpreter looks in lib/python3.13/site-packages, finds nothing, and every
+# dependency silently vanishes. The assertion in the runtime stage enforces this.
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
 
 WORKDIR /build
 
@@ -110,6 +117,39 @@ ENV PATH="/app/.venv/bin:$PATH" \
     HOME="/home/app" \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
+
+# Fail the BUILD rather than the container. This is not hypothetical: the image
+# shipped with a 3.12 builder and a 3.13 runtime, so sys.path contained no
+# site-packages at all and `docker run <image>` died on "No module named
+# uvicorn". It built clean and published clean every time, because nothing in
+# CI or in the publish workflow ever started it.
+#
+# uvicorn is what CMD invokes. pydantic_core is a compiled extension, so it also
+# catches an ABI mismatch that a pure-Python import would sail straight past.
+RUN /app/.venv/bin/python <<'PYCHECK'
+import pathlib
+import sys
+
+tag = f"python{sys.version_info.major}.{sys.version_info.minor}"
+lib = pathlib.Path("/app/.venv/lib")
+if not (lib / tag / "site-packages").is_dir():
+    have = sorted(p.name for p in lib.iterdir())
+    sys.exit(
+        f"venv/runtime Python mismatch: interpreter is {tag}, but the copied "
+        f"venv provides {have}. Align the builder stage's uv:pythonX.Y tag "
+        f"with the runtime FROM."
+    )
+
+import fastapi  # noqa: F401
+import pydantic_core
+import pydantic_settings  # noqa: F401
+import uvicorn  # noqa: F401
+
+print(
+    f"runtime OK: Python {sys.version.split()[0]}, "
+    f"pydantic_core {pydantic_core.__version__}"
+)
+PYCHECK
 
 USER app
 


### PR DESCRIPTION
> **This is a production-impacting bug on `main`, not a dependency chore.** Every published container image fails to start. I have **not** merged it — it changes the production base image, which is a decision for you.

## The bug

`docker run` on the released image:

```
/app/.venv/bin/python: No module named uvicorn
```

The builder stage resolves dependencies on `uv:python3.12-bookworm-slim`; the runtime stage runs `python:3.13-slim`. The venv is copied wholesale between them — but a venv keeps its packages at the version-stamped `lib/python3.X/site-packages`, and its `bin/python` is only a symlink to `/usr/local/bin/python`, which resolves to the **runtime** interpreter, not the builder's.

So Python 3.13 looked for `lib/python3.13/site-packages`, found only `lib/python3.12`, and started with no site-packages on `sys.path` at all:

```python
>>> sys.prefix
'/app/.venv'
>>> sys.path
['', '/usr/local/lib/python313.zip', '/usr/local/lib/python3.13', '/usr/local/lib/python3.13/lib-dynload']
```

## Why every gate stayed green

Nothing ever ran the image. `docker-publish.yml` builds → pushes → writes a summary. A `docker build` that succeeds proves only that the layers assembled.

This is the same failure family as the `kubeintellect --version` regression that reached PyPI under a green install-smoke job, and as #142 passing 15 checks while `npm run lint` was dead (#157). The pattern each time: **the artifact was produced but never exercised.**

## The fix

Builder aligned to `uv:python3.13-bookworm-slim`, plus two guards:

1. **In the Dockerfile** — asserts the copied venv matches the running interpreter, and that `uvicorn`, `fastapi`, `pydantic_core`, `pydantic_settings` import. Because it lives in the Dockerfile it protects the *publish* path too, not just CI.
2. **A `Container image (build + serve)` CI job** — starts the image against Postgres and requires a 200 from `/healthz`. That is the part an import assertion cannot cover.

## Verification

| | `docker build` | `docker run` → `/healthz` |
|---|---|---|
| `main` (`a47c83d`) | 0 | **`No module named uvicorn`** |
| this branch | 0 (`runtime OK: Python 3.13.15, pydantic_core 2.46.4`) | **200** |

```
HTTP=200  {"status":"ok","arm":"v4","version":"0+unknown","experimental_flags":["MEMORY_HIERARCHY_ENABLED"]}
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000
```

Also confirmed the assertion *fails correctly*: an earlier iteration caught a genuinely-absent `numpy` and stopped the build. `numpy` is declared only in the workspace-root `pyproject.toml` and no runtime module imports it, so it is correctly not in the image — `pydantic_core` covers the compiled-extension ABI case instead.

## Bearing on #71

#71 bumps **only** the runtime to `3.14-slim`, which would leave the same mismatch in place (3.12 builder → 3.14 runtime). This PR deliberately aligns on **3.13** — the version `main` already declares — so it is a pure fix and does not pre-empt the 3.14 decision. Moving to 3.14 afterwards means changing **both** stages, and the new job would prove it before it ships.