### PR TITLE
chore(lint): clear the ruff 0.16 modernization families (362 → 210) and guard the UP045 autofix trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   still calls. The job runs `npm ci` rather than `npm install` so a lockfile that disagrees with
   the manifest fails instead of being silently re-resolved.
 
+### Changed
+- **ruff 0.16 backlog: 362 → 210 findings** (#75), clearing every modernization family —
+  `UP045`/`UP006`/`UP035`/`UP037` (typing syntax), `I001`, `PIE810`, `RUF059`, `RUF012`,
+  `FURB162`, `FURB188`, `RUF015`, `SIM102`/`SIM113`/`SIM114`, `C408`, `F401`, `F841`,
+  `ISC004`, `PLR0124`. Both suites (1047 + 317), mypy and the pinned lint gate stay green.
+
+  **One finding in that set was a trap, and it is now guarded.**
+  `ruff --select UP045 --fix` rewrites the canary inside
+  `tests/test_injected_config_invariant.py` from `Annotated[Optional[RunnableConfig],
+  InjectedToolArg]` to `Annotated[RunnableConfig | None, InjectedToolArg]` — **and the suite
+  still reports 8 passed.** Neither spelling is in langchain_core's match list, so the canary
+  goes on reporting `None` either way; the autofix leaves a green test that no longer exercises
+  the exact form AGENTS.md invariant #6 forbids. That line now carries a suppression and the
+  reasoning, matching the existing one on `app/agent/nodes/coordinator.py`, where the same
+  rewrite would silently stop the run config being injected and take `user_role` and
+  `hitl_bypass` with it.
+
+  Also fixed while in there: `ki_protocol/events.py` caught `(ValidationError, Exception)`,
+  which is exactly `except Exception` because `ValidationError` is a subclass — the tuple only
+  made the intent read narrower than it was. The breadth is deliberate for that decoder, so it
+  is now stated plainly.
+
+  The `ruff<0.16` pin stays for now. The remainder is **141 `BLE001`** (blind-except, mostly
+  deliberate CLI and agent boundary handlers) and **30 `PLW1510`**; both are project-wide policy
+  calls rather than cleanup, and are tracked in #75.
+
 ### Fixed
 - **The published container image could not start.** `docker run` on any released image failed
   immediately with `No module named uvicorn`, and it had been that way since the image was

--- a/v4/packages/ki-protocol/ki_protocol/events.py
+++ b/v4/packages/ki-protocol/ki_protocol/events.py
@@ -162,7 +162,6 @@ def parse_event(raw: dict[str, Any]) -> Event | None:
 
     Returns None for unknown/malformed events.
     """
-    from pydantic import ValidationError
 
     # Normalise legacy ki_event format: type is at top level, data fields also
     # at top level (no nested "data" key).
@@ -173,5 +172,10 @@ def parse_event(raw: dict[str, Any]) -> Event | None:
 
     try:
         return _event_adapter.validate_python(raw)
-    except (ValidationError, Exception):
+    # `except (ValidationError, Exception)` was the same as `except Exception`:
+    # ValidationError is a subclass, so listing it changed nothing and only made
+    # the intent read as narrower than it is. The breadth is deliberate — this
+    # decoder's contract is "return None for anything I cannot decode" — so it is
+    # stated plainly rather than dressed up.
+    except Exception:  # noqa: BLE001
         return None

--- a/v4/packages/kube-q/kube_q/cli/help_text.py
+++ b/v4/packages/kube-q/kube_q/cli/help_text.py
@@ -18,37 +18,37 @@ from kube_q.cli.renderer import console
 _TOPICS: dict[str, tuple[str, str]] = {
     "messages": (
         "Sending messages, multi-line input, paste",
-        "[accent.bold]Sending messages[/accent.bold]\n\n"
+        ("[accent.bold]Sending messages[/accent.bold]\n\n"
         "  [accent]Enter[/accent]            Send your message\n"
         "  [accent]Alt+Enter[/accent]        Insert a newline  [muted](hold Alt, press Enter)[/muted]\n"
         "  [accent]Esc → Enter[/accent]      Insert a newline  [muted](universal fallback)[/muted]\n\n"
-        "  Paste multi-line text freely — newlines are preserved before you send.",
+        "  Paste multi-line text freely — newlines are preserved before you send."),
     ),
     "files": (
         "Attaching files with @path",
-        "[accent.bold]Attaching files[/accent.bold]\n\n"
+        ("[accent.bold]Attaching files[/accent.bold]\n\n"
         "  Type [accent]@path/to/file[/accent] anywhere in your message to attach a file.\n"
         "  Its contents are embedded as a code block and sent with your message.\n\n"
         "  [accent]@deployment.yaml[/accent]          Attach a file in the current directory\n"
         "  [accent]@~/configs/service.json[/accent]   Home-relative path\n"
         "  [accent]@\"/path/with spaces.txt\"[/accent]   Quote paths with spaces\n\n"
         "  Multiple files per message are fine: [muted]What's wrong? @pod.yaml @svc.yaml[/muted]\n"
-        "  Supported: YAML, JSON, Python, Shell, Go, Terraform, text, logs… (100 KB/file).",
+        "  Supported: YAML, JSON, Python, Shell, Go, Terraform, text, logs… (100 KB/file)."),
     ),
     "editing": (
         "Keyboard shortcuts and auto-complete",
-        "[accent.bold]Editing[/accent.bold]\n\n"
+        ("[accent.bold]Editing[/accent.bold]\n\n"
         "  [accent]Tab[/accent]              Auto-complete slash commands, /context, /profile, /ns, /save\n"
         "  [accent]↑ / ↓[/accent]            Scroll through previous messages (history)\n"
         "  [accent]Ctrl+A / Ctrl+E[/accent]  Jump to start / end of line\n"
         "  [accent]Ctrl+W[/accent]           Delete previous word\n"
         "  [accent]Ctrl+U[/accent]           Clear the input buffer\n"
         "  [accent]Ctrl+C[/accent]           Cancel current input (keeps history)\n"
-        "  [accent]Ctrl+D[/accent]           Exit the session",
+        "  [accent]Ctrl+D[/accent]           Exit the session"),
     ),
     "conversation": (
         "/new /id /state /title /save /clear /version",
-        "[accent.bold]Conversation[/accent.bold]\n\n"
+        ("[accent.bold]Conversation[/accent.bold]\n\n"
         "  [accent]/new[/accent]             Start a fresh conversation (new ID, clears history)\n"
         "  [accent]/id[/accent]              Show the current conversation ID\n"
         "  [accent]/state[/accent]           Full session state (ID, namespace, tokens, HITL flag)\n"
@@ -56,25 +56,25 @@ _TOPICS: dict[str, tuple[str, str]] = {
         "  [accent]/save [file][/accent]     Save conversation to markdown  [muted](Tab completes paths)[/muted]\n"
         "  [accent]/clear[/accent]           Clear the terminal screen\n"
         "  [accent]/version[/accent]         Print the installed kube-q version\n"
-        "  [accent]/quit[/accent]  [muted]/exit /q[/muted]   Exit kube-q",
+        "  [accent]/quit[/accent]  [muted]/exit /q[/muted]   Exit kube-q"),
     ),
     "namespace": (
         "/ns — set the active namespace",
-        "[accent.bold]Namespace[/accent.bold]\n\n"
+        ("[accent.bold]Namespace[/accent.bold]\n\n"
         "  [accent]/ns <name>[/accent]       Set active namespace — prepended to every query\n"
         "  [accent]/ns[/accent]              Clear the active namespace\n\n"
-        "  [muted]Tab-completes from the cluster (cached after first use).[/muted]",
+        "  [muted]Tab-completes from the cluster (cached after first use).[/muted]"),
     ),
     "context": (
         "/context — set the kubectl context",
-        "[accent.bold]Kubernetes context[/accent.bold]\n\n"
+        ("[accent.bold]Kubernetes context[/accent.bold]\n\n"
         "  [accent]/context <name>[/accent]  Set active kubectl context — prepended to every query\n"
         "  [accent]/context[/accent]         List / clear the active context\n\n"
-        "  [muted]Tab-completes from your kubeconfig.[/muted]",
+        "  [muted]Tab-completes from your kubeconfig.[/muted]"),
     ),
     "sessions": (
         "/sessions /list /history /forget /resume",
-        "[accent.bold]Session history[/accent.bold]\n\n"
+        ("[accent.bold]Session history[/accent.bold]\n\n"
         "  [accent]/sessions[/accent]        Interactive picker — ↑/↓ navigate, Enter resume, Esc cancel\n"
         "  [accent]/resume[/accent]          Alias for /sessions\n"
         "  [accent]/list[/accent]            Print recent sessions as a table (no picker)\n"
@@ -82,45 +82,45 @@ _TOPICS: dict[str, tuple[str, str]] = {
         "  [accent]/history N[/accent]       Last N messages\n"
         "  [accent]/history X-Y[/accent]     Messages X through Y  [muted](1-indexed, inclusive)[/muted]\n"
         "  [accent]/history #N[/accent]      Just message #N\n"
-        "  [accent]/forget[/accent]          Delete current session from local history  [muted](server untouched)[/muted]",
+        "  [accent]/forget[/accent]          Delete current session from local history  [muted](server untouched)[/muted]"),
     ),
     "search": (
         "/search and /branch — find & fork",
-        "[accent.bold]Search & branching[/accent.bold]\n\n"
+        ("[accent.bold]Search & branching[/accent.bold]\n\n"
         "  [accent]/search <query>[/accent]  Full-text search across all past sessions\n"
         "  [muted]    /search \"crash loop\" AND production[/muted]\n"
         "  [muted]    /search \"oom killed\" OR \"memory limit\"[/muted]\n"
         "  [accent]/branch[/accent]          Fork this conversation at the current point\n"
-        "  [accent]/branches[/accent]        List all forks (and siblings) of this session",
+        "  [accent]/branches[/accent]        List all forks (and siblings) of this session"),
     ),
     "profiles": (
         "/profile and /plugins",
-        "[accent.bold]Profiles & plugins[/accent.bold]\n\n"
+        ("[accent.bold]Profiles & plugins[/accent.bold]\n\n"
         "  [accent]/profile[/accent]              List profiles in ~/.kube-q/profiles/\n"
         "  [accent]/profile new <name>[/accent]   Create a profile .env from template\n"
         "  [accent]/profile show <name>[/accent]  Print a profile's contents\n"
         "  [accent]/profile delete <name>[/accent] Delete a profile file\n"
         "  [muted]Switching profiles requires a restart: [accent]kq --profile <name>[/accent][/muted]\n\n"
-        "  [accent]/plugins[/accent]              List loaded plugins from ~/.kube-q/plugins/",
+        "  [accent]/plugins[/accent]              List loaded plugins from ~/.kube-q/plugins/"),
     ),
     "tokens": (
         "/tokens — usage and cost",
-        "[accent.bold]Token usage[/accent.bold]\n\n"
+        ("[accent.bold]Token usage[/accent.bold]\n\n"
         "  [accent]/tokens[/accent]  [muted]/cost[/muted]    Token counts and estimated cost for this session\n\n"
         "  Override rates via [muted]KUBE_Q_COST_PER_1K_PROMPT[/muted] / "
-        "[muted]KUBE_Q_COST_PER_1K_COMPLETION[/muted].",
+        "[muted]KUBE_Q_COST_PER_1K_COMPLETION[/muted]."),
     ),
     "hitl": (
         "Human-in-the-loop approvals",
-        "[accent.bold]Human-in-the-Loop (HITL)[/accent.bold]\n\n"
+        ("[accent.bold]Human-in-the-Loop (HITL)[/accent.bold]\n\n"
         "  When kube-q proposes a [warn]write action[/warn] (deploy, delete, scale…) it pauses\n"
         "  and shows the command. The prompt changes to [warn]HITL>[/warn].\n\n"
         "  [accent]/approve[/accent]         Execute the pending action\n"
-        "  [accent]/deny[/accent]            Cancel it — nothing is applied",
+        "  [accent]/deny[/accent]            Cancel it — nothing is applied"),
     ),
     "config": (
         "/config and ~/.kube-q/.env keys",
-        "[accent.bold]Connection & config[/accent.bold]\n\n"
+        ("[accent.bold]Connection & config[/accent.bold]\n\n"
         "  [accent]/config[/accent]                Print all keys, values, and their sources\n"
         "  [accent]/config set KEY=VALUE[/accent]  Write a key to ~/.kube-q/.env  [muted](takes effect now)[/muted]\n"
         "  [muted]    /config set url=https://api.kubeintellect.com[/muted]\n"
@@ -130,11 +130,11 @@ _TOPICS: dict[str, tuple[str, str]] = {
         "  [accent]/config reset[/accent]          Wipe ~/.kube-q/.env entirely\n\n"
         "  [muted]Common keys: KUBE_Q_URL, KUBE_Q_API_KEY, KUBE_Q_MODEL, KUBE_Q_STREAM,[/muted]\n"
         "  [muted]KUBE_Q_OUTPUT, KUBE_Q_USER_NAME, KUBE_Q_AGENT_NAME, KUBE_Q_CONTEXT.[/muted]\n"
-        "  [muted]Logs: ~/.kube-q/kube-q.log[/muted]",
+        "  [muted]Logs: ~/.kube-q/kube-q.log[/muted]"),
     ),
     "flags": (
         "Useful launch flags (kq --...)",
-        "[accent.bold]Useful launch flags[/accent.bold]\n\n"
+        ("[accent.bold]Useful launch flags[/accent.bold]\n\n"
         "  [muted]kq --query \"...\"[/muted]            One-shot query, then exit\n"
         "  [muted]kq --url <URL>[/muted]              Connect to a specific API server\n"
         "  [muted]kq --api-key <key>[/muted]          Authenticate with an API key\n"
@@ -145,7 +145,7 @@ _TOPICS: dict[str, tuple[str, str]] = {
         "  [muted]kq --model <name>[/muted]           Override the model name\n"
         "  [muted]kq --profile <name>[/muted]         Load ~/.kube-q/profiles/<name>.env\n"
         "  [muted]kq --backend kube-q|openai|azure[/muted]  Pick the LLM backend\n"
-        "  [muted]kq --debug[/muted]                  Show raw HTTP request/response log",
+        "  [muted]kq --debug[/muted]                  Show raw HTTP request/response log"),
     ),
 }
 

--- a/v4/packages/kube-q/kube_q/cli/sessions_ui.py
+++ b/v4/packages/kube-q/kube_q/cli/sessions_ui.py
@@ -147,7 +147,7 @@ def _parse_history_spec(spec: str, total: int) -> tuple[int, int] | None:
     spec = spec.strip()
     if not spec:
         return (1, total)
-    if spec.startswith("#") or spec.startswith("@"):
+    if spec.startswith(("#", "@")):
         try:
             n = int(spec[1:])
         except ValueError:

--- a/v4/packages/kube-q/tests/test_session.py
+++ b/v4/packages/kube-q/tests/test_session.py
@@ -49,7 +49,7 @@ def test_resolve_attachments_missing_file(tmp_path: Path) -> None:
 def test_resolve_attachments_file_too_large(tmp_path: Path) -> None:
     big = tmp_path / "big.txt"
     big.write_bytes(b"x" * (101 * 1024))  # 101 KB > 100 KB limit
-    expanded, attached, errors = _resolve_attachments(f"@{big}")
+    _expanded, attached, errors = _resolve_attachments(f"@{big}")
     assert len(errors) == 1
     assert "too large" in errors[0]
     assert attached == []
@@ -80,7 +80,7 @@ def test_resolve_attachments_multiple_files(tmp_path: Path) -> None:
 def test_resolve_attachments_unknown_extension(tmp_path: Path) -> None:
     f = tmp_path / "notes.xyz"
     f.write_text("some content")
-    expanded, attached, errors = _resolve_attachments(f"@{f}")
+    expanded, _attached, errors = _resolve_attachments(f"@{f}")
     assert errors == []
     # Unknown extension → fence with no language specifier
     assert "```\n" in expanded or "```" in expanded
@@ -88,7 +88,7 @@ def test_resolve_attachments_unknown_extension(tmp_path: Path) -> None:
 
 def test_resolve_attachments_not_a_file(tmp_path: Path) -> None:
     msg = f"@{tmp_path}"  # directory, not a file
-    expanded, attached, errors = _resolve_attachments(msg)
+    _expanded, _attached, errors = _resolve_attachments(msg)
     assert len(errors) == 1
     assert "not a regular file" in errors[0]
 

--- a/v4/packages/kube-q/tests/test_subcommands.py
+++ b/v4/packages/kube-q/tests/test_subcommands.py
@@ -92,7 +92,7 @@ def test_known_subcommand_dispatches_and_returns_exit_code(monkeypatch):
 
     # get_runner imports the module and reads .run at call time, so patching the
     # module attribute is enough.
-    import kube_q.cli.findings_cmd as findings_cmd
+    from kube_q.cli import findings_cmd
 
     monkeypatch.setattr(findings_cmd, "run", fake_run)
     monkeypatch.setattr("sys.argv", ["kq", "findings", "--limit", "5"])

--- a/v4/packages/kube-q/tests/test_transport.py
+++ b/v4/packages/kube-q/tests/test_transport.py
@@ -269,7 +269,7 @@ def test_non_stream_query_http_error() -> None:
     respx.post(f"{BASE}/v1/chat/completions").mock(
         return_value=httpx.Response(500, text="Internal Server Error")
     )
-    text, hitl, action_id, _usage = non_stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
+    text, hitl, _action_id, _usage = non_stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
     assert text == ""
     assert hitl is False
 
@@ -279,7 +279,7 @@ def test_non_stream_query_invalid_json() -> None:
     respx.post(f"{BASE}/v1/chat/completions").mock(
         return_value=httpx.Response(200, content=b"not-json")
     )
-    text, hitl, _, _usage = non_stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
+    text, _hitl, _, _usage = non_stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
     assert text == ""
 
 
@@ -288,7 +288,7 @@ def test_non_stream_query_missing_keys() -> None:
     respx.post(f"{BASE}/v1/chat/completions").mock(
         return_value=httpx.Response(200, json={"choices": []})  # empty choices
     )
-    text, hitl, _, _usage = non_stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
+    text, _hitl, _, _usage = non_stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
     assert text == ""
 
 
@@ -310,7 +310,7 @@ def test_non_stream_query_hitl_emoji_fallback() -> None:
     respx.post(f"{BASE}/v1/chat/completions").mock(
         return_value=httpx.Response(200, json=_ok_body("needs approval 🛑"))
     )
-    text, hitl, _, _usage = non_stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
+    _text, hitl, _, _usage = non_stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
     assert hitl is True
 
 
@@ -324,7 +324,7 @@ def test_non_stream_query_retry_then_succeed() -> None:
         ]
     )
     with patch("kube_q.transport.time.sleep"):  # don't actually sleep
-        text, hitl, _, _usage = non_stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
+        text, _hitl, _, _usage = non_stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
     assert text == "ok on retry"
 
 
@@ -335,7 +335,7 @@ def test_non_stream_query_all_retries_fail() -> None:
         side_effect=httpx.ConnectError("refused")
     )
     with patch("kube_q.transport.time.sleep"):
-        text, hitl, _, _usage = non_stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
+        text, _hitl, _, _usage = non_stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
     assert text == ""
 
 
@@ -410,7 +410,7 @@ def test_stream_query_returns_usage_dict_when_present() -> None:
                                     headers={"Content-Type": "text/event-stream"})
     )
     with patch("kube_q.transport.Live"):
-        text, hitl, action_id, returned_usage = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
+        _text, _hitl, _action_id, returned_usage = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
     assert returned_usage is not None
     assert returned_usage["prompt_tokens"] == 120
     assert returned_usage["completion_tokens"] == 340
@@ -424,7 +424,7 @@ def test_stream_query_returns_none_usage_when_absent() -> None:
                                     headers={"Content-Type": "text/event-stream"})
     )
     with patch("kube_q.transport.Live"):
-        text, hitl, action_id, returned_usage = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
+        _text, _hitl, _action_id, returned_usage = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
     assert returned_usage is None
 
 
@@ -443,7 +443,7 @@ def test_non_stream_query_returns_usage_dict_when_present() -> None:
     respx.post(f"{BASE}/v1/chat/completions").mock(
         return_value=httpx.Response(200, json=body)
     )
-    text, hitl, action_id, returned_usage = non_stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
+    _text, _hitl, _action_id, returned_usage = non_stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
     assert returned_usage is not None
     assert returned_usage["prompt_tokens"] == 50
     assert returned_usage["total_tokens"] == 150
@@ -455,7 +455,7 @@ def test_non_stream_query_returns_none_usage_when_absent() -> None:
     respx.post(f"{BASE}/v1/chat/completions").mock(
         return_value=httpx.Response(200, json=body)
     )
-    text, hitl, action_id, returned_usage = non_stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
+    _text, _hitl, _action_id, returned_usage = non_stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
     assert returned_usage is None
 
 
@@ -465,7 +465,7 @@ def test_stream_query_error_returns_none_usage() -> None:
         return_value=httpx.Response(500, text="error")
     )
     with patch("kube_q.transport.Live"):
-        text, hitl, action_id, returned_usage = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
+        text, _hitl, _action_id, returned_usage = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
     assert text == ""
     assert returned_usage is None
 
@@ -475,7 +475,7 @@ def test_non_stream_query_error_returns_none_usage() -> None:
     respx.post(f"{BASE}/v1/chat/completions").mock(
         return_value=httpx.Response(500, text="error")
     )
-    text, hitl, action_id, returned_usage = non_stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
+    text, _hitl, _action_id, returned_usage = non_stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
     assert text == ""
     assert returned_usage is None
 
@@ -495,7 +495,7 @@ def test_stream_query_usage_in_same_event_as_choices() -> None:
                                     headers={"Content-Type": "text/event-stream"})
     )
     with patch("kube_q.transport.Live"):
-        text, hitl, action_id, returned_usage = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
+        _text, _hitl, _action_id, returned_usage = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
     assert returned_usage is not None
     assert returned_usage["total_tokens"] == 30
 
@@ -520,7 +520,7 @@ def test_stream_query_ki_status_events_do_not_add_to_text() -> None:
                                     headers={"Content-Type": "text/event-stream"})
     )
     with patch("kube_q.transport.Live"):
-        text, hitl, action_id, _ = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
+        text, _hitl, _action_id, _ = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
     assert text == "result"
 
 
@@ -536,7 +536,7 @@ def test_stream_query_ki_tool_call_events_do_not_add_to_text() -> None:
                                     headers={"Content-Type": "text/event-stream"})
     )
     with patch("kube_q.transport.Live"):
-        text, hitl, action_id, _ = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
+        text, _hitl, _action_id, _ = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
     assert text == "done"
 
 
@@ -552,7 +552,7 @@ def test_stream_query_ki_error_events_do_not_add_to_text() -> None:
                                     headers={"Content-Type": "text/event-stream"})
     )
     with patch("kube_q.transport.Live"):
-        text, hitl, action_id, _ = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
+        text, _hitl, _action_id, _ = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
     assert text == "partial"
 
 
@@ -569,7 +569,7 @@ def test_stream_query_ki_usage_type_captured() -> None:
                                     headers={"Content-Type": "text/event-stream"})
     )
     with patch("kube_q.transport.Live"):
-        text, hitl, action_id, usage = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
+        text, _hitl, _action_id, usage = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
     assert text == "ok"
     assert usage is not None
     assert usage["prompt_tokens"] == 80
@@ -589,7 +589,7 @@ def test_stream_query_ki_usage_nested_key_captured() -> None:
                                     headers={"Content-Type": "text/event-stream"})
     )
     with patch("kube_q.transport.Live"):
-        text, hitl, action_id, usage = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
+        _text, _hitl, _action_id, usage = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
     assert usage is not None
     assert usage["prompt_tokens"] == 50
 
@@ -609,7 +609,7 @@ def test_stream_query_mixed_ki_and_openai_events() -> None:
                                     headers={"Content-Type": "text/event-stream"})
     )
     with patch("kube_q.transport.Live"):
-        text, hitl, action_id, _ = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
+        text, hitl, _action_id, _ = stream_query(BASE, _MESSAGES, _SESSION_ID, _USER)
     assert text == "All pods healthy"
     assert hitl is False
 

--- a/v4/packages/kubeintellect-server/app/agent/nodes/coordinator.py
+++ b/v4/packages/kubeintellect-server/app/agent/nodes/coordinator.py
@@ -625,9 +625,9 @@ def _playbooks_block(state: AgentState) -> str:
     except Exception:
         return ""
 
-    sections: list[str] = ["\n## Recognized Failure Patterns\n"
+    sections: list[str] = [("\n## Recognized Failure Patterns\n"
                            "The snapshot matches these known patterns. Follow their\n"
-                           "investigation steps before improvising.\n"]
+                           "investigation steps before improvising.\n")]
     for name in matched:
         pb = get_playbook(name)
         if pb is None:
@@ -956,7 +956,7 @@ def _wait_for_rollout(namespace: str, max_wait_s: int = 30, poll_interval_s: flo
                 continue
             status = cols[2]
             # `Init:0/1` etc — match the prefix.
-            if status in _TRANSITIONAL_STATUSES or status.startswith("Init:") or status.startswith("PodInitializing"):
+            if status in _TRANSITIONAL_STATUSES or status.startswith(("Init:", "PodInitializing")):
                 in_transition = True
                 break
         if not in_transition:
@@ -997,7 +997,7 @@ def _verify_resolution(namespace: str | None, pre_state: dict | None = None) -> 
             "--sort-by=.lastTimestamp",
             "--field-selector=type=Warning",
         ])
-        has_issues, has_warnings, _ = _scan_snapshot(pods_out, events_out)
+        has_issues, _has_warnings, _ = _scan_snapshot(pods_out, events_out)
 
         if not has_issues:
             # Pods are healthy — even if old warning events linger, the fix
@@ -1171,8 +1171,7 @@ Synthesize these into a single root-cause analysis. Respond with ONLY a JSON obj
     raw = response.text.strip()
     if raw.startswith("```"):
         raw = raw.split("```")[1]
-        if raw.startswith("json"):
-            raw = raw[4:]
+        raw = raw.removeprefix("json")
 
     try:
         rca = RCAResult.model_validate(json.loads(raw.strip()))

--- a/v4/packages/kubeintellect-server/app/agent/nodes/subagent.py
+++ b/v4/packages/kubeintellect-server/app/agent/nodes/subagent.py
@@ -108,8 +108,7 @@ async def run_subagent(payload: SubagentInput) -> AgentFinding:
         clean = raw_content.strip()
         if clean.startswith("```"):
             clean = clean.split("```")[1]
-            if clean.startswith("json"):
-                clean = clean[4:]
+            clean = clean.removeprefix("json")
         finding = AgentFinding.model_validate(json.loads(clean.strip()))
     except Exception as exc:
         logger.warning(f"subagent [{domain}]: failed to parse finding JSON — {exc}")

--- a/v4/packages/kubeintellect-server/app/agent/playbooks/loader.py
+++ b/v4/packages/kubeintellect-server/app/agent/playbooks/loader.py
@@ -18,9 +18,9 @@ Schema (one .yaml file per playbook):
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable
 
 import yaml
 

--- a/v4/packages/kubeintellect-server/app/agent/workflow.py
+++ b/v4/packages/kubeintellect-server/app/agent/workflow.py
@@ -403,7 +403,7 @@ async def stream_events(
 # ── Typed-event translation ───────────────────────────────────────────────────
 
 
-def _translate_raw_event(session_id: str, raw: dict) -> "ToolCallEvent | ToolResultEvent | TokenEvent | HitlRequestEvent | None":
+def _translate_raw_event(session_id: str, raw: dict) -> ToolCallEvent | ToolResultEvent | TokenEvent | HitlRequestEvent | None:
     """
     Convert a LangGraph astream_events v2 dict to a typed emitter Event.
 

--- a/v4/packages/kubeintellect-server/app/api/v1/endpoints/chat_completions.py
+++ b/v4/packages/kubeintellect-server/app/api/v1/endpoints/chat_completions.py
@@ -20,7 +20,7 @@ import asyncio
 import json
 import time
 import uuid
-from typing import AsyncIterator
+from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse

--- a/v4/packages/kubeintellect-server/app/autonomy/blast_radius.py
+++ b/v4/packages/kubeintellect-server/app/autonomy/blast_radius.py
@@ -11,7 +11,6 @@ Pure composition over the individual gates (each already tested) — determinist
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
 
 from app.autonomy.budget import BudgetDecision
 from app.autonomy.failure_domain import DomainDecision
@@ -29,7 +28,7 @@ def compose(
     *,
     budget: BudgetDecision,
     stage: StageDecision,
-    domain: Optional[DomainDecision] = None,
+    domain: DomainDecision | None = None,
 ) -> BlastRadiusVerdict:
     """Compose the blast-radius controls. Order: budget → domain → propagation.
 

--- a/v4/packages/kubeintellect-server/app/autonomy/budget.py
+++ b/v4/packages/kubeintellect-server/app/autonomy/budget.py
@@ -20,7 +20,6 @@ A3 decision behind ``KI_V5_BLAST_RADIUS_BUDGET``; off ⇒ the ladder is unchange
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
 
 from app.core.config import settings
 
@@ -48,7 +47,7 @@ def kill_switch_engaged() -> bool:
     return bool(_runtime_kill or settings.KI_V5_KILL_SWITCH)
 
 
-def check_spend(current: float, projected: float, cap: Optional[float]) -> BudgetDecision:
+def check_spend(current: float, projected: float, cap: float | None) -> BudgetDecision:
     """Deny-before-breach: block if the projected spend would push the scope over ``cap``.
 
     A non-positive/None cap means unlimited. Deterministic; ``current``/``projected`` are supplied
@@ -71,9 +70,9 @@ def gate_write(
     governance_ok: bool = True,
     current_spend: float = 0.0,
     projected_spend: float = 0.0,
-    spend_cap: Optional[float] = None,
-    now_epoch: Optional[float] = None,
-    freeze_windows: Optional[list[tuple[float, float]]] = None,
+    spend_cap: float | None = None,
+    now_epoch: float | None = None,
+    freeze_windows: list[tuple[float, float]] | None = None,
 ) -> BudgetDecision:
     """Full composable write gate. Fail-closed: any brake or unreachable governance ⇒ deny.
 

--- a/v4/packages/kubeintellect-server/app/autonomy/failure_domain.py
+++ b/v4/packages/kubeintellect-server/app/autonomy/failure_domain.py
@@ -12,7 +12,6 @@ Pure/deterministic — fully unit-testable.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -53,8 +52,8 @@ def gate_disruption(
     zone_total: int,
     currently_unavailable: int,
     max_unavailable_frac: float = 0.34,
-    now_epoch: Optional[float] = None,
-    maintenance_windows: Optional[list[tuple[float, float]]] = None,
+    now_epoch: float | None = None,
+    maintenance_windows: list[tuple[float, float]] | None = None,
 ) -> DomainDecision:
     """Compose the failure-domain + change-schedule checks. First denial wins (schedule → domain)."""
     if now_epoch is not None and maintenance_windows and not in_maintenance_window(now_epoch, maintenance_windows):

--- a/v4/packages/kubeintellect-server/app/autonomy/promotion_engine.py
+++ b/v4/packages/kubeintellect-server/app/autonomy/promotion_engine.py
@@ -14,8 +14,8 @@ against the P0 replay fixtures.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Callable, Optional
 
 from app.autonomy.promotion_stats import (
     Event,
@@ -66,7 +66,7 @@ def decide(
     current_rung: str,
     now_days: float,
     *,
-    events: Optional[list[Event]] = None,
+    events: list[Event] | None = None,
     sev_attributed: bool = False,
     m4_at_l4: bool = False,
     class_drift: bool = False,

--- a/v4/packages/kubeintellect-server/app/autonomy/promotion_stats.py
+++ b/v4/packages/kubeintellect-server/app/autonomy/promotion_stats.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from typing import Literal, Optional
+from typing import Literal
 
 # One-sided z for α=0.05.
 _Z_95 = 1.6448536269514722
@@ -31,7 +31,7 @@ RollbackClass = Literal["versioned-workload", "declarative-revert", "irreversibl
 class TransitionRule:
     frm: Rung
     to: Rung
-    theta: Optional[float]        # LCB₉₅ threshold; None ⇒ never
+    theta: float | None        # LCB₉₅ threshold; None ⇒ never
     n_min: int
     t_min_days: int
     min_incidents: int
@@ -65,7 +65,7 @@ class PromotionDecision:
     transition: str
     lcb: float
     n: int
-    theta: Optional[float]
+    theta: float | None
     reasons: list[str] = field(default_factory=list)  # which gates failed (empty ⇒ all passed)
 
 

--- a/v4/packages/kubeintellect-server/app/autonomy/staged_propagation.py
+++ b/v4/packages/kubeintellect-server/app/autonomy/staged_propagation.py
@@ -11,7 +11,6 @@ Pure/deterministic (clock injected) — fully unit-testable.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -28,7 +27,7 @@ def next_stage(
     *,
     stage_size: int = 1,
     window_seconds: float = 300.0,
-    last_stage_epoch: Optional[float] = None,
+    last_stage_epoch: float | None = None,
     now_epoch: float = 0.0,
 ) -> StageDecision:
     """Decide the next propagation stage.

--- a/v4/packages/kubeintellect-server/app/cli.py
+++ b/v4/packages/kubeintellect-server/app/cli.py
@@ -116,7 +116,7 @@ def _validate_config(cfg: dict) -> list[_Issue]:
 
     # DATABASE_URL format ───────────────────────────────────────────────────────
     db_url = cfg.get("DATABASE_URL", "").strip()
-    if db_url and not (db_url.startswith("postgresql://") or db_url.startswith("postgres://")):
+    if db_url and not (db_url.startswith(("postgresql://", "postgres://"))):
         issues.append(_Issue(
             "DATABASE_URL", "error",
             "DATABASE_URL does not look like a valid PostgreSQL DSN.",
@@ -132,7 +132,7 @@ def _validate_config(cfg: dict) -> list[_Issue]:
         ("LANGFUSE_HOST",  "http://langfuse-web.monitoring.svc.cluster.local:3000"),
     ):
         url = cfg.get(key, "").strip()
-        if url and not (url.startswith("http://") or url.startswith("https://")):
+        if url and not (url.startswith(("http://", "https://"))):
             issues.append(_Issue(
                 key, "warn",
                 f"{key} is set but does not look like a valid URL: {url!r}",
@@ -1507,7 +1507,7 @@ def cmd_set(args: argparse.Namespace) -> None:
         new_line = f"{key}={value}\n"
         replaced = False
         for i, line in enumerate(lines):
-            if line.startswith(f"{key}=") or line.startswith(f"{key} ="):
+            if line.startswith((f"{key}=", f"{key} =")):
                 lines[i] = new_line
                 replaced = True
                 break

--- a/v4/packages/kubeintellect-server/app/core/config.py
+++ b/v4/packages/kubeintellect-server/app/core/config.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Optional
 
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -30,8 +29,8 @@ class Settings(BaseSettings):
     LLM_PROVIDER: str = Field(default="azure")
 
     # Azure OpenAI
-    AZURE_OPENAI_API_KEY: Optional[str] = None
-    AZURE_OPENAI_ENDPOINT: Optional[str] = None
+    AZURE_OPENAI_API_KEY: str | None = None
+    AZURE_OPENAI_ENDPOINT: str | None = None
     AZURE_OPENAI_API_VERSION: str = "2024-10-01-preview"  # enables automatic prefix caching
     AZURE_COORDINATOR_DEPLOYMENT: str = "gpt-4o"
     AZURE_SUBAGENT_DEPLOYMENT: str = "gpt-4o-mini"
@@ -39,20 +38,20 @@ class Settings(BaseSettings):
     # OpenAI direct (also used for any OpenAI-compatible endpoint, e.g. Alibaba
     # DashScope / Qwen: set OPENAI_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
     # with LLM_PROVIDER=openai and OPENAI_*_MODEL=qwen-max / qwen-plus).
-    OPENAI_API_KEY: Optional[str] = None
-    OPENAI_BASE_URL: Optional[str] = None  # override for OpenAI-compatible providers (Qwen/DashScope, LiteLLM, etc.)
+    OPENAI_API_KEY: str | None = None
+    OPENAI_BASE_URL: str | None = None  # override for OpenAI-compatible providers (Qwen/DashScope, LiteLLM, etc.)
     OPENAI_COORDINATOR_MODEL: str = "gpt-4o"
     OPENAI_SUBAGENT_MODEL: str = "gpt-4o-mini"
     # Alibaba DashScope / Qwen key aliases. The OpenAI-compatible client reads the
     # key from OPENAI_API_KEY, but when LLM_PROVIDER=qwen you can name it honestly:
     # DASHSCOPE_API_KEY (Alibaba's own convention) or QWEN_API_KEY populate it.
-    DASHSCOPE_API_KEY: Optional[str] = None
-    QWEN_API_KEY: Optional[str] = None
+    DASHSCOPE_API_KEY: str | None = None
+    QWEN_API_KEY: str | None = None
 
     # ── PostgreSQL ────────────────────────────────────────────────────────────
     # When DATABASE_URL is set (e.g. external managed DB), it takes precedence
     # over the individual POSTGRES_* vars below.
-    DATABASE_URL: Optional[str] = None
+    DATABASE_URL: str | None = None
     POSTGRES_HOST: str = "localhost"
     POSTGRES_PORT: str = "5432"
     POSTGRES_DB: str = "kubeintellect"
@@ -62,7 +61,7 @@ class Settings(BaseSettings):
     POSTGRES_POOL_MAX_CONN: int = Field(default=10, gt=0)
 
     @property
-    def POSTGRES_DSN(self) -> Optional[str]:
+    def POSTGRES_DSN(self) -> str | None:
         if self.USE_SQLITE:
             return None
         if self.DATABASE_URL:
@@ -121,8 +120,8 @@ class Settings(BaseSettings):
     LOKI_URL: str = ""
 
     LANGFUSE_ENABLED: bool = False
-    LANGFUSE_PUBLIC_KEY: Optional[str] = None
-    LANGFUSE_SECRET_KEY: Optional[str] = None
+    LANGFUSE_PUBLIC_KEY: str | None = None
+    LANGFUSE_SECRET_KEY: str | None = None
     # Set by each deployment method: localhost:3001 (compose), in-cluster DNS (Helm).
     # Empty default keeps Langfuse disabled until a host is explicitly configured.
     LANGFUSE_HOST: str = ""
@@ -446,7 +445,7 @@ class Settings(BaseSettings):
     KI_V5_SANDBOX_WRITER_SA: str = "ki-writer"
 
     # Anthropic provider (optional; LLM_PROVIDER=anthropic, needs langchain-anthropic)
-    ANTHROPIC_API_KEY: Optional[str] = None
+    ANTHROPIC_API_KEY: str | None = None
     ANTHROPIC_LARGE_MODEL: str = "claude-sonnet-4-6"
     ANTHROPIC_SMALL_MODEL: str = "claude-haiku-4-5-20251001"
 
@@ -479,7 +478,7 @@ class Settings(BaseSettings):
     # Secret used to sign and verify HMAC demo keys (AUTH_BACKEND=hmac).
     # Rotate to invalidate all outstanding demo keys instantly.
     # Generate: openssl rand -hex 32
-    DEMO_KEY_HMAC_SECRET: Optional[str] = None
+    DEMO_KEY_HMAC_SECRET: str | None = None
 
     # Default TTL for demo keys minted via POST /v1/auth/demo-keys.
     DEMO_KEY_DEFAULT_TTL_HOURS: int = Field(default=24 * 7)   # 7 days
@@ -568,7 +567,7 @@ class Settings(BaseSettings):
         return self
 
 
-def _load_settings() -> "Settings":
+def _load_settings() -> Settings:
     """Load Settings, converting Pydantic validation errors into readable messages."""
     import sys as _sys
     try:

--- a/v4/packages/kubeintellect-server/app/core/llm.py
+++ b/v4/packages/kubeintellect-server/app/core/llm.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import os
 from functools import lru_cache
-from typing import Any, List, Type
+from typing import Any
 
 from langchain_core.language_models import BaseChatModel
 from pydantic import SecretStr
@@ -20,10 +20,10 @@ def _secret(value: str | None) -> SecretStr | None:
 
 # Resolved once at import time so the ImportError warning fires only on startup,
 # not on every request.  None = not yet resolved, False = unavailable.
-_LangfuseCallbackHandler: Type[Any] | None | bool = None
+_LangfuseCallbackHandler: type[Any] | None | bool = None
 
 
-def _resolve_langfuse() -> Type[Any] | None:
+def _resolve_langfuse() -> type[Any] | None:
     global _LangfuseCallbackHandler
     if _LangfuseCallbackHandler is not None:
         return None if _LangfuseCallbackHandler is False else _LangfuseCallbackHandler  # type: ignore[return-value]
@@ -37,7 +37,7 @@ def _resolve_langfuse() -> Type[Any] | None:
         return None
 
 
-def get_langfuse_callbacks() -> List[Any]:
+def get_langfuse_callbacks() -> list[Any]:
     """Return [CallbackHandler()] if Langfuse tracing is enabled, else [].
 
     Langfuse v4 reads LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY / LANGFUSE_HOST from

--- a/v4/packages/kubeintellect-server/app/cortex/briefs.py
+++ b/v4/packages/kubeintellect-server/app/cortex/briefs.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -55,7 +55,7 @@ class EscalationBrief:
     fell_back: bool = False
 
 
-def _parse_json_object(text: str) -> Optional[dict[str, Any]]:
+def _parse_json_object(text: str) -> dict[str, Any] | None:
     if not isinstance(text, str):
         return None
     match = re.search(r"\{.*\}", text, re.DOTALL)
@@ -91,7 +91,7 @@ def _fallback(level: str) -> EscalationBrief:
 
 async def build_brief(
     root_cause: str, evidence: str, *, responder_level: str = "intermediate",
-    llm: Optional[BaseChatModel] = None,
+    llm: BaseChatModel | None = None,
 ) -> EscalationBrief:
     """Build a skill-calibrated escalation-avoidance brief. Fails safe to a conservative brief."""
     level = _normalize_level(responder_level)

--- a/v4/packages/kubeintellect-server/app/cortex/change_rca.py
+++ b/v4/packages/kubeintellect-server/app/cortex/change_rca.py
@@ -13,8 +13,8 @@ The ranking/rendering here is pure and fully tested against injected changes.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable, Optional
 
 from app.utils.logger import get_logger
 
@@ -31,10 +31,10 @@ class ChangeRecord:
 
 
 # Pluggable ledger source (P1 registers the real one). Signature: (cluster_id, namespace|None).
-ChangeSource = Callable[[str, Optional[str]], list[ChangeRecord]]
+ChangeSource = Callable[[str, str | None], list[ChangeRecord]]
 
 
-def _empty_source(cluster_id: str, namespace: Optional[str] = None) -> list[ChangeRecord]:
+def _empty_source(cluster_id: str, namespace: str | None = None) -> list[ChangeRecord]:
     return []
 
 
@@ -47,7 +47,7 @@ def set_change_source(fn: ChangeSource) -> None:
     _change_source = fn
 
 
-def recent_changes(cluster_id: str, namespace: Optional[str] = None) -> list[ChangeRecord]:
+def recent_changes(cluster_id: str, namespace: str | None = None) -> list[ChangeRecord]:
     """Read recent changes from the registered source. Never raises (fails to no changes)."""
     try:
         return list(_change_source(cluster_id, namespace))
@@ -62,7 +62,7 @@ def rank_by_recency(changes: list[ChangeRecord]) -> list[ChangeRecord]:
 
 
 def render_change_prior(
-    changes: list[ChangeRecord], *, max_items: int = 5, now: Optional[float] = None,
+    changes: list[ChangeRecord], *, max_items: int = 5, now: float | None = None,
 ) -> str:
     """Recency-ranked 'consider these changes first' prompt block. '' when there are no changes."""
     ranked = rank_by_recency(changes)[:max_items]

--- a/v4/packages/kubeintellect-server/app/cortex/harness/runner.py
+++ b/v4/packages/kubeintellect-server/app/cortex/harness/runner.py
@@ -20,7 +20,8 @@ Stability contract (this is the "most stable" bar the whole feature is default-o
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Awaitable, Callable, Optional
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
@@ -90,8 +91,8 @@ async def run_subagent(
     config: RunnableConfig,
     *,
     snapshot: str = "",
-    llm: Optional[BaseChatModel] = None,
-    max_rounds: Optional[int] = None,
+    llm: BaseChatModel | None = None,
+    max_rounds: int | None = None,
 ) -> SubagentResult:
     """Run one isolated read-only investigator to a bounded, structured summary.
 
@@ -165,7 +166,7 @@ async def run_fanout(
     state: CortexState,
     config: RunnableConfig,
     *,
-    runner: Optional[SubagentRunner] = None,
+    runner: SubagentRunner | None = None,
 ) -> dict:
     """Dispatch the parallel read-only investigation fan-out for one gather round.
 

--- a/v4/packages/kubeintellect-server/app/cortex/responsiveness.py
+++ b/v4/packages/kubeintellect-server/app/cortex/responsiveness.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Awaitable, Callable, Optional
 
 from app.streaming.emitter import Event, StatusEvent
 from app.streaming.emitter import emit as _default_emit
@@ -40,7 +40,7 @@ async def heartbeat(
     message: str,
     *,
     interval: float = 10.0,
-    emit_fn: Optional[EmitFn] = None,
+    emit_fn: EmitFn | None = None,
 ):
     """Emit a progress StatusEvent every ``interval`` s until the wrapped block exits.
 
@@ -81,11 +81,11 @@ class PhaseBudget:
     clock: Clock = time.monotonic
 
     _start: float = 0.0
-    _first_signal_at: Optional[float] = None
+    _first_signal_at: float | None = None
 
     @classmethod
     def since(cls, start: float, *, first_signal_s: float = 30.0, full_s: float = 120.0,
-              clock: Clock = time.monotonic) -> "PhaseBudget":
+              clock: Clock = time.monotonic) -> PhaseBudget:
         """Build a budget already started at a known monotonic ``start`` (e.g. from graph state)."""
         b = cls(first_signal_s=first_signal_s, full_s=full_s, clock=clock)
         b._start = start

--- a/v4/packages/kubeintellect-server/app/cortex/verify.py
+++ b/v4/packages/kubeintellect-server/app/cortex/verify.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -61,7 +61,7 @@ class RcaReview:
     errored: bool = False  # the reviewer failed and we failed open
 
 
-def _parse_json_object(text: str) -> Optional[dict[str, Any]]:
+def _parse_json_object(text: str) -> dict[str, Any] | None:
     """Extract the first JSON object from an LLM reply; None if unparseable."""
     if not isinstance(text, str):
         return None
@@ -82,7 +82,7 @@ def _clean_list(value: Any) -> list[str]:
 
 
 async def evaluate_goal(
-    objective: str, evidence: str, *, llm: Optional[BaseChatModel] = None,
+    objective: str, evidence: str, *, llm: BaseChatModel | None = None,
 ) -> GoalVerdict:
     """Stop-gate: is ``evidence`` sufficient for ``objective``? Fails open to sufficient=True
     (never trap the loop into gathering forever on a reviewer error)."""
@@ -105,7 +105,7 @@ async def evaluate_goal(
 
 
 async def review_rca(
-    claim: str, evidence: str, *, llm: Optional[BaseChatModel] = None,
+    claim: str, evidence: str, *, llm: BaseChatModel | None = None,
 ) -> RcaReview:
     """Adversarial fresh-context review of a claim against evidence. Fails OPEN to supported=True
     with ``errored=True`` so a broken reviewer never contradicts a sound answer."""
@@ -138,8 +138,8 @@ def render_review_note(review: RcaReview) -> str:
     worth surfacing (supported, or the reviewer failed open)."""
     if review.errored or (review.supported and not review.unsupported):
         return ""
-    lines = ["", "---", "**⚠ Verification:** the adversarial reviewer flagged claims the gathered "
-             "evidence does not fully support:"]
+    lines = ["", "---", ("**⚠ Verification:** the adversarial reviewer flagged claims the gathered "
+             "evidence does not fully support:")]
     lines.extend(f"- {item}" for item in review.unsupported)
     if review.confidence:
         lines.append(f"\n_Reviewer confidence in the RCA: {review.confidence:.0%}._")

--- a/v4/packages/kubeintellect-server/app/db/otel_spans.py
+++ b/v4/packages/kubeintellect-server/app/db/otel_spans.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from app.core.config import settings
 from app.db import flight_recorder
@@ -46,7 +46,7 @@ def _base(
     episode_id: str,
     seq: int,
     operation: str,
-    parent_span_id: Optional[str],
+    parent_span_id: str | None,
     attributes: dict[str, Any],
 ) -> dict[str, Any]:
     return {
@@ -60,7 +60,7 @@ def _base(
 
 def chat_span_payload(
     episode_id: str, seq: int, *, system: str, model: str,
-    input_tokens: int, output_tokens: int, parent_span_id: Optional[str] = None,
+    input_tokens: int, output_tokens: int, parent_span_id: str | None = None,
 ) -> dict[str, Any]:
     """A GenAI ``chat`` span; its ``gen_ai.usage.*`` is the single spend source."""
     return _base(episode_id, seq, OP_CHAT, parent_span_id, {
@@ -73,7 +73,7 @@ def chat_span_payload(
 
 def tool_span_payload(
     episode_id: str, seq: int, *, tool_name: str, ok: bool,
-    parent_span_id: Optional[str] = None, mcp: bool = False,
+    parent_span_id: str | None = None, mcp: bool = False,
 ) -> dict[str, Any]:
     return _base(episode_id, seq, OP_MCP if mcp else OP_TOOL, parent_span_id, {
         "gen_ai.tool.name": tool_name,
@@ -84,7 +84,7 @@ def tool_span_payload(
 def mutation_span_payload(
     episode_id: str, seq: int, *, action: str,
     hypothesis_span_ids: list[str], evidence_span_ids: list[str],
-    parent_span_id: Optional[str] = None,
+    parent_span_id: str | None = None,
 ) -> dict[str, Any]:
     """A cluster-mutating span. Provenance is enforced at build time: it MUST link
     ≥1 hypothesis and ≥1 evidence span, else ``ki.provenance_incomplete=true`` +

--- a/v4/packages/kubeintellect-server/app/detectors/agentic_gpu.py
+++ b/v4/packages/kubeintellect-server/app/detectors/agentic_gpu.py
@@ -10,7 +10,6 @@ cluster; wiring them to the live sensorium watch stream is the follow-up (same a
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -30,7 +29,7 @@ class AgentSignal:
 
 def detect_agent_runaway(
     sig: AgentSignal, *, rate_cap: float = 60.0, cost_cap: float = 1.0,
-) -> Optional[DetectorHit]:
+) -> DetectorHit | None:
     """Flag an agent that is looping / burning spend / probing its sandbox."""
     if sig.sandbox_escape_attempts > 0:
         return DetectorHit("sandbox-escape", "critical",
@@ -53,7 +52,7 @@ class GpuSignal:
     gpu_oom: int = 0                 # GPU out-of-memory events
 
 
-def detect_gpu_unhealthy(sig: GpuSignal) -> Optional[DetectorHit]:
+def detect_gpu_unhealthy(sig: GpuSignal) -> DetectorHit | None:
     """Flag GPU/device-plane trouble that starves agentic/inference workloads."""
     if sig.ecc_errors > 0:
         return DetectorHit("gpu-unhealthy", "critical",

--- a/v4/packages/kubeintellect-server/app/detectors/agentic_gpu_collector.py
+++ b/v4/packages/kubeintellect-server/app/detectors/agentic_gpu_collector.py
@@ -9,7 +9,7 @@ Prometheus; the default reads the live PromQL endpoint.
 
 from __future__ import annotations
 
-from typing import Callable, Optional
+from collections.abc import Callable
 
 from app.detectors.agentic_gpu import (
     AgentSignal,
@@ -44,7 +44,7 @@ def _default_scalar(promql: str) -> float:
 
 
 def collect_and_detect(
-    *, scalar: Optional[ScalarFn] = None, rate_cap: float = 60.0, cost_cap: float = 1.0,
+    *, scalar: ScalarFn | None = None, rate_cap: float = 60.0, cost_cap: float = 1.0,
 ) -> list[DetectorHit]:
     """Query the metrics, run the agentic + GPU predicates, return the hits (empty when healthy)."""
     s = scalar or _default_scalar

--- a/v4/packages/kubeintellect-server/app/digest/builder.py
+++ b/v4/packages/kubeintellect-server/app/digest/builder.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 import time
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 
 from app.utils.logger import get_logger
 
@@ -80,9 +80,7 @@ async def build_digest(hours: float = 24.0) -> dict:
                 "rollback_id": payload.get("rollback_id", ""),
                 "command": payload.get("command", ""),
             })
-        elif episode.startswith("auto-"):
-            sessions.add(episode)
-        elif not episode.startswith("findings:"):
+        elif episode.startswith("auto-") or not episode.startswith("findings:"):
             sessions.add(episode)
 
     digest["user_sessions"] = len({s for s in sessions if not s.startswith("auto-")})

--- a/v4/packages/kubeintellect-server/app/eval/opsmembench.py
+++ b/v4/packages/kubeintellect-server/app/eval/opsmembench.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import json
 import math
 from dataclasses import asdict, dataclass, field
-from typing import Optional
 
 from app.db.flight_recorder import compute_hash
 
@@ -111,7 +110,7 @@ def build_grade(
     scorecard: ScoreCard,
     harness: HarnessSpec,
     snapshot_layers: dict[str, str],
-    notes: Optional[list[str]] = None,
+    notes: list[str] | None = None,
 ) -> GradeArtifact:
     art = GradeArtifact(
         scorecard=scorecard,

--- a/v4/packages/kubeintellect-server/app/memory/change_ledger.py
+++ b/v4/packages/kubeintellect-server/app/memory/change_ledger.py
@@ -14,12 +14,11 @@ only needs *recent* changes, and a restart losing them degrades gracefully (empt
 from __future__ import annotations
 
 from collections import defaultdict, deque
-from typing import Deque, Optional
 
 from app.cortex.change_rca import ChangeRecord, _empty_source, set_change_source
 
 _MAX_PER_CLUSTER = 200
-_ledger: dict[str, Deque[ChangeRecord]] = defaultdict(lambda: deque(maxlen=_MAX_PER_CLUSTER))
+_ledger: dict[str, deque[ChangeRecord]] = defaultdict(lambda: deque(maxlen=_MAX_PER_CLUSTER))
 _installed = False
 
 # kubectl mutating verb → change kind.
@@ -33,7 +32,7 @@ _VERB_KIND = {
 _SET_SUBS = {"image", "env", "resources", "serviceaccount", "selector"}
 
 
-def parse_kubectl_change(cmd: str, ts_epoch: float, namespace: str = "") -> Optional[ChangeRecord]:
+def parse_kubectl_change(cmd: str, ts_epoch: float, namespace: str = "") -> ChangeRecord | None:
     """Parse a mutating kubectl command into a ChangeRecord, or None if not a recognized change."""
     toks = cmd.strip().split()
     if toks and toks[0] == "kubectl":
@@ -60,7 +59,7 @@ def record_change(cluster_id: str, record: ChangeRecord) -> None:
     _ledger[cluster_id].append(record)
 
 
-def recent(cluster_id: str, namespace: Optional[str] = None) -> list[ChangeRecord]:
+def recent(cluster_id: str, namespace: str | None = None) -> list[ChangeRecord]:
     """The change-source reader registered with change_rca (most-recent-first is handled there)."""
     items = list(_ledger.get(cluster_id, ()))
     if namespace:

--- a/v4/packages/kubeintellect-server/app/memory/episodes.py
+++ b/v4/packages/kubeintellect-server/app/memory/episodes.py
@@ -12,7 +12,7 @@ catches, logs, and returns a safe empty value.
 from __future__ import annotations
 
 import json
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 from typing import Any
 
 from app.core.config import settings

--- a/v4/packages/kubeintellect-server/app/memory/file_plane.py
+++ b/v4/packages/kubeintellect-server/app/memory/file_plane.py
@@ -11,8 +11,9 @@ injectable orchestrator (fetchers + writer) so the whole thing is unit-testable 
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any
 
 from app.utils.logger import get_logger
 
@@ -99,9 +100,9 @@ async def regenerate_file_plane(
     cluster_id: str,
     out_dir: str | Path,
     *,
-    fetch_episodes: Optional[EpisodeFetcher] = None,
-    fetch_themes: Optional[ThemesFetcher] = None,
-    writer: Optional[Writer] = None,
+    fetch_episodes: EpisodeFetcher | None = None,
+    fetch_themes: ThemesFetcher | None = None,
+    writer: Writer | None = None,
     max_bytes: int = DEFAULT_MAX_BYTES,
 ) -> dict[str, int]:
     """Regenerate CLUSTER.md + MEMORY.md for ``cluster_id`` into ``out_dir``. Returns byte counts.

--- a/v4/packages/kubeintellect-server/app/memory/fleet_exchange.py
+++ b/v4/packages/kubeintellect-server/app/memory/fleet_exchange.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 from collections import defaultdict, deque
 from dataclasses import dataclass
-from typing import Deque, Optional
 
 _MAX_PER_TENANT = 500
 
@@ -28,7 +27,7 @@ class FleetEntry:
 
 
 # tenant → ring buffer of entries. Partitioned by tenant so a read can NEVER cross tenants.
-_store: dict[str, Deque[FleetEntry]] = defaultdict(lambda: deque(maxlen=_MAX_PER_TENANT))
+_store: dict[str, deque[FleetEntry]] = defaultdict(lambda: deque(maxlen=_MAX_PER_TENANT))
 
 
 def publish(entry: FleetEntry) -> None:
@@ -36,8 +35,8 @@ def publish(entry: FleetEntry) -> None:
     _store[entry.tenant].append(entry)
 
 
-def read_fleet(tenant: str, *, exclude_cluster: Optional[str] = None,
-               signature: Optional[str] = None) -> list[FleetEntry]:
+def read_fleet(tenant: str, *, exclude_cluster: str | None = None,
+               signature: str | None = None) -> list[FleetEntry]:
     """Read a tenant's fleet knowledge. STRICT isolation: only ``tenant``'s partition is ever
     consulted. Optionally drop the reading cluster's own entries and filter by signature."""
     items = list(_store.get(tenant, ()))

--- a/v4/packages/kubeintellect-server/app/memory/fleet_store_pg.py
+++ b/v4/packages/kubeintellect-server/app/memory/fleet_store_pg.py
@@ -10,7 +10,7 @@ Async over asyncpg; the pool is injected so this composes with the app's existin
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from app.memory.fleet_exchange import FleetEntry
 
@@ -31,8 +31,8 @@ async def publish(pool: Any, entry: FleetEntry) -> None:
 
 
 async def read_fleet(
-    pool: Any, tenant: str, *, exclude_cluster: Optional[str] = None,
-    signature: Optional[str] = None, limit: int = 200,
+    pool: Any, tenant: str, *, exclude_cluster: str | None = None,
+    signature: str | None = None, limit: int = 200,
 ) -> list[FleetEntry]:
     """Read a tenant's fleet knowledge. The ``tenant = $1`` predicate is the isolation boundary —
     no query path returns another tenant's rows."""

--- a/v4/packages/kubeintellect-server/app/memory/kg.py
+++ b/v4/packages/kubeintellect-server/app/memory/kg.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import json
 import time
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 from typing import Any
 
 import asyncpg

--- a/v4/packages/kubeintellect-server/app/memory/prospective.py
+++ b/v4/packages/kubeintellect-server/app/memory/prospective.py
@@ -24,7 +24,7 @@ prospective failure must never break a request or stall the consolidation loop.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 from typing import Any
 
 from app.autonomy.ladder import at_least, level_for_namespace

--- a/v4/packages/kubeintellect-server/app/memory/writeback.py
+++ b/v4/packages/kubeintellect-server/app/memory/writeback.py
@@ -14,8 +14,9 @@ write-back *mechanism* here is complete and takes whatever signals it is given.
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any
 
 from app.utils.logger import get_logger
 
@@ -49,7 +50,7 @@ def signals_from_investigation(cluster_id: str, playbooks: list[str]) -> list[Ed
 
 
 async def apply_writeback(
-    cluster_id: str, signals: list[EdgeSignal], *, reconcile: Optional[ReconcileFn] = None,
+    cluster_id: str, signals: list[EdgeSignal], *, reconcile: ReconcileFn | None = None,
 ) -> dict[str, int]:
     """Reconcile each edge signal. Returns a tally of reconcile decisions. Never raises out."""
     tally: dict[str, int] = {}

--- a/v4/packages/kubeintellect-server/app/sensorium/change_watchdog.py
+++ b/v4/packages/kubeintellect-server/app/sensorium/change_watchdog.py
@@ -12,8 +12,8 @@ exactly as prospective memory defers its dispatch.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable, Optional
 
 from app.cortex.change_rca import ChangeRecord
 from app.utils.logger import get_logger
@@ -40,7 +40,7 @@ def _dedup_key(change: ChangeRecord) -> str:
 
 def plan_watchdogs(
     changes: list[ChangeRecord], *, now_epoch: float, ttl_seconds: int = 300,
-    max_active: int = 5, since_epoch: float = 0.0, seen: Optional[set[str]] = None,
+    max_active: int = 5, since_epoch: float = 0.0, seen: set[str] | None = None,
 ) -> list[WatchdogTask]:
     """Arm a watchdog per recent, not-yet-watched change (most recent first), bounded by max_active.
 

--- a/v4/packages/kubeintellect-server/app/sensorium/k8s_watcher.py
+++ b/v4/packages/kubeintellect-server/app/sensorium/k8s_watcher.py
@@ -87,7 +87,7 @@ def _event_timestamp(obj: dict) -> float | None:
         return None
     try:
         from datetime import datetime
-        return datetime.fromisoformat(str(raw).replace("Z", "+00:00")).timestamp()
+        return datetime.fromisoformat(str(raw)).timestamp()
     except ValueError:
         return None
 

--- a/v4/packages/kubeintellect-server/app/sensorium/pre_capture.py
+++ b/v4/packages/kubeintellect-server/app/sensorium/pre_capture.py
@@ -13,7 +13,7 @@ pluggable side effect (like prospective memory / watchdog dispatch).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 # pre-capture actions (what to arm before the predicted death)
 LOG_VERBOSITY = "raise_log_verbosity"
@@ -32,8 +32,8 @@ class PreCapturePlan:
 
 
 def plan_pre_capture(
-    finding: Any, *, eta_threshold_min: float = 15.0, actions: Optional[list[str]] = None,
-) -> Optional[PreCapturePlan]:
+    finding: Any, *, eta_threshold_min: float = 15.0, actions: list[str] | None = None,
+) -> PreCapturePlan | None:
     """Plan pre-capture for an imminent predicted finding, else None (targeted spend).
 
     Only fires for a ``severity=="predicted"`` finding whose ETA is within ``eta_threshold_min`` —

--- a/v4/packages/kubeintellect-server/app/sensorium/watchdog_dispatch.py
+++ b/v4/packages/kubeintellect-server/app/sensorium/watchdog_dispatch.py
@@ -12,7 +12,8 @@ injectable so the wiring is unit-testable without an LLM.
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Awaitable, Callable, Optional
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 from langchain_core.messages import HumanMessage
 
@@ -44,7 +45,7 @@ def _watchdog_state(task: WatchdogTask) -> dict:
     }
 
 
-async def investigate(task: WatchdogTask, *, runner: Optional[Runner] = None) -> Any:
+async def investigate(task: WatchdogTask, *, runner: Runner | None = None) -> Any:
     """Run one watchdog's bounded read-only investigation. Never raises out."""
     active: Runner
     if runner is None:

--- a/v4/packages/kubeintellect-server/app/tools/aci/gitops.py
+++ b/v4/packages/kubeintellect-server/app/tools/aci/gitops.py
@@ -12,8 +12,8 @@ without git, gh, or a network.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable, Optional
 
 from app.tools.aci.fix_pr import FixPR
 
@@ -52,7 +52,7 @@ class PRResult:
 
 def open_pr(
     fix: FixPR, *, repo_dir: str, branch: str, base: str = "main", remote: str = "origin",
-    runner: Optional[Runner] = None,
+    runner: Runner | None = None,
 ) -> PRResult:
     """Push ``branch`` and open a PR for ``fix``. Fails safe (a no-op fix opens nothing)."""
     if fix.is_noop:

--- a/v4/packages/kubeintellect-server/app/tools/aci/models.py
+++ b/v4/packages/kubeintellect-server/app/tools/aci/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Literal, Optional
+from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -28,15 +28,15 @@ class Health(str, Enum):
 class InspectInput(BaseModel):
     kind: str = Field(description="Kubernetes kind, e.g. 'deployment', 'pod'.")
     name: str = Field(description="Object name.")
-    namespace: Optional[str] = Field(default=None, description="Namespace; omit for cluster-scoped.")
+    namespace: str | None = Field(default=None, description="Namespace; omit for cluster-scoped.")
     view: Literal["summary", "status", "full"] = "summary"
 
 
 class SearchInput(BaseModel):
     kinds: list[str] = Field(min_length=1, description="One or more kinds to list.")
-    namespace: Optional[str] = None
+    namespace: str | None = None
     all_namespaces: bool = False
-    selector: Optional[str] = Field(default=None, description="Label selector, e.g. 'app=web'.")
+    selector: str | None = Field(default=None, description="Label selector, e.g. 'app=web'.")
     limit: int = Field(default=100, ge=1, le=100)
 
     @field_validator("limit")
@@ -47,11 +47,11 @@ class SearchInput(BaseModel):
 
 class LogsInput(BaseModel):
     namespace: str
-    pod: Optional[str] = None
-    selector: Optional[str] = Field(default=None, description="Label selector (mutually exclusive with pod).")
-    container: Optional[str] = None
+    pod: str | None = None
+    selector: str | None = Field(default=None, description="Label selector (mutually exclusive with pod).")
+    container: str | None = None
     lines: int = Field(default=100, ge=1, le=100)
-    since: Optional[str] = Field(default=None, description="e.g. '5m', '1h'.")
+    since: str | None = Field(default=None, description="e.g. '5m', '1h'.")
     previous: bool = Field(default=False, description="Read last terminated container (dead-pod evidence).")
 
 
@@ -59,9 +59,9 @@ class DiffChangeInput(BaseModel):
     against: Literal["live", "previous", "git"]
     kind: str
     name: str
-    namespace: Optional[str] = None
-    manifest: Optional[str] = Field(default=None, description="Proposed YAML for against=live.")
-    revision: Optional[int] = Field(default=None, description="Prior revision for against=previous.")
+    namespace: str | None = None
+    manifest: str | None = Field(default=None, description="Proposed YAML for against=live.")
+    revision: int | None = Field(default=None, description="Prior revision for against=previous.")
 
 
 # ── Output envelope (the replay artifact) ─────────────────────────────────────
@@ -71,13 +71,13 @@ class AciResult(BaseModel):
     rollback_class: Literal["R0"] = "R0"  # every v0 verb is read-only
     target: str
     kubectl_command: str
-    health: Optional[Health] = None
+    health: Health | None = None
     total_lines: int = 0
     shown_lines: int = 0
-    cursor: Optional[int] = None
+    cursor: int | None = None
     body: str = ""
     empty: bool = False
-    error: Optional[str] = None
+    error: str | None = None
 
     def render(self) -> str:
         """The bounded string the model sees. Never empty (R-aci-empty-01)."""

--- a/v4/packages/kubeintellect-server/app/tools/aci/mutating.py
+++ b/v4/packages/kubeintellect-server/app/tools/aci/mutating.py
@@ -13,7 +13,6 @@ Actual execution, server-side `--dry-run`, and Kyverno/VAP admission are separat
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
 
 from app.autonomy.budget import BudgetDecision, gate_write
 
@@ -127,9 +126,9 @@ def validate_mutation(command: str, *, _runner=None) -> DryRunResult:
 
 
 def plan_mutation(
-    command: str, *, earned_rung: str = "L2", budget: Optional[BudgetDecision] = None,
+    command: str, *, earned_rung: str = "L2", budget: BudgetDecision | None = None,
     _runner=None,
-) -> tuple[MutationProposal, Optional[DryRunResult]]:
+) -> tuple[MutationProposal, DryRunResult | None]:
     """The full chokepoint: authorize (budget+rung+reversibility) → server-side dry-run.
 
     Only runs the dry-run when the write is authorized (not denied) — a denied write is never even

--- a/v4/packages/kubeintellect-server/app/tools/aci/postcondition.py
+++ b/v4/packages/kubeintellect-server/app/tools/aci/postcondition.py
@@ -12,7 +12,6 @@ cluster read goes through the run_kubectl seam and is injectable for tests.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -23,7 +22,7 @@ class PostconditionResult:
     detail: str = ""
 
 
-def parse_ready_column(get_output: str, name: str) -> Optional[tuple[int, int]]:
+def parse_ready_column(get_output: str, name: str) -> tuple[int, int] | None:
     """Parse (ready, desired) from a `kubectl get deployment` table row for ``name``.
 
     The READY column is "ready/desired" (e.g. "3/3"). Returns None if the row/column is absent.

--- a/v4/packages/kubeintellect-server/app/tools/aci/read_verbs.py
+++ b/v4/packages/kubeintellect-server/app/tools/aci/read_verbs.py
@@ -8,7 +8,7 @@ whose ``render()`` is the never-silent string the model sees.
 
 from __future__ import annotations
 
-from typing import Annotated, Optional
+from typing import Annotated
 
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import InjectedToolArg, tool
@@ -38,7 +38,7 @@ def _exec(command: str) -> str:
     return run_kubectl.invoke({"command": command})
 
 
-def _ns_flag(namespace: Optional[str], all_namespaces: bool = False) -> str:
+def _ns_flag(namespace: str | None, all_namespaces: bool = False) -> str:
     if all_namespaces:
         return " --all-namespaces"
     return f" -n {namespace}" if namespace else ""
@@ -99,7 +99,7 @@ def _health_from(body: str) -> Health:
 async def inspect(
     kind: str,
     name: str,
-    namespace: Optional[str] = None,
+    namespace: str | None = None,
     view: str = "summary",
     # INVARIANT (AGENTS.md #6): this annotation must stay bare `RunnableConfig`.
     # langchain_core matches the injected run config by identity (`type_ is
@@ -124,9 +124,9 @@ async def inspect(
 @tool(args_schema=SearchInput)
 async def search(
     kinds: list[str],
-    namespace: Optional[str] = None,
+    namespace: str | None = None,
     all_namespaces: bool = False,
-    selector: Optional[str] = None,
+    selector: str | None = None,
     limit: int = 100,
     # INVARIANT (AGENTS.md #6): this annotation must stay bare `RunnableConfig`.
     # langchain_core matches the injected run config by identity (`type_ is
@@ -147,11 +147,11 @@ async def search(
 @tool(args_schema=LogsInput)
 async def logs(
     namespace: str,
-    pod: Optional[str] = None,
-    selector: Optional[str] = None,
-    container: Optional[str] = None,
+    pod: str | None = None,
+    selector: str | None = None,
+    container: str | None = None,
     lines: int = 100,
-    since: Optional[str] = None,
+    since: str | None = None,
     previous: bool = False,
     # INVARIANT (AGENTS.md #6): this annotation must stay bare `RunnableConfig`.
     # langchain_core matches the injected run config by identity (`type_ is
@@ -185,9 +185,9 @@ async def diff_change(
     against: str,
     kind: str,
     name: str,
-    namespace: Optional[str] = None,
-    manifest: Optional[str] = None,
-    revision: Optional[int] = None,
+    namespace: str | None = None,
+    manifest: str | None = None,
+    revision: int | None = None,
     # INVARIANT (AGENTS.md #6): this annotation must stay bare `RunnableConfig`.
     # langchain_core matches the injected run config by identity (`type_ is
     # RunnableConfig`), so `Optional[RunnableConfig]` is NOT matched and the tool

--- a/v4/packages/kubeintellect-server/app/tools/aci/repair.py
+++ b/v4/packages/kubeintellect-server/app/tools/aci/repair.py
@@ -10,8 +10,6 @@ the downstream fix-PR is a no-op (nothing is proposed) rather than a corrupted m
 
 from __future__ import annotations
 
-from typing import Optional
-
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
 
@@ -39,7 +37,7 @@ def _strip_fences(text: str) -> str:
 
 
 async def propose_fix(
-    manifest: str, violation: str, *, llm: Optional[BaseChatModel] = None,
+    manifest: str, violation: str, *, llm: BaseChatModel | None = None,
 ) -> str:
     """Propose a corrected manifest for ``violation``. Returns the ORIGINAL on any failure."""
     try:

--- a/v4/packages/kubeintellect-server/app/tools/aci/transactional.py
+++ b/v4/packages/kubeintellect-server/app/tools/aci/transactional.py
@@ -12,8 +12,8 @@ path — reachable only for chokepoint-authorized, reversible classes).
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable, Optional
 
 from app.tools.aci.postcondition import PostconditionResult
 
@@ -44,7 +44,7 @@ def _default_apply(command: str) -> str:
 @dataclass(frozen=True)
 class ExecutionResult:
     status: str
-    postcondition: Optional[PostconditionResult] = None
+    postcondition: PostconditionResult | None = None
     apply_output: str = ""
     rollback_output: str = ""
 
@@ -53,8 +53,8 @@ def execute_transactional(
     command: str,
     postcondition: PostconditionFn,
     *,
-    rollback_command: Optional[str] = None,
-    apply_fn: Optional[ApplyFn] = None,
+    rollback_command: str | None = None,
+    apply_fn: ApplyFn | None = None,
 ) -> ExecutionResult:
     """Apply ``command``, verify the ``postcondition`` oracle, roll back on failure.
 

--- a/v4/packages/kubeintellect-server/app/tools/kubectl_tool.py
+++ b/v4/packages/kubeintellect-server/app/tools/kubectl_tool.py
@@ -515,9 +515,8 @@ def run_kubectl(
     # Safety Sandwich (V4 ADR-003): arm a rollback point before any mutation —
     # the pre-state YAML of the targets lands in the flight recorder, so every
     # destructive action is undoable from the audit trail.
-    if verb in _HIGH_RISK or verb in _MEDIUM_RISK:
-        if not has_dry_run:
-            _capture_rollback_point(verb, args, stdin, config, env)
+    if (verb in _HIGH_RISK or verb in _MEDIUM_RISK) and not has_dry_run:
+        _capture_rollback_point(verb, args, stdin, config, env)
 
     logger.debug(f"run_kubectl: {cmd}")
 

--- a/v4/scripts/check_doc_claims.py
+++ b/v4/scripts/check_doc_claims.py
@@ -66,7 +66,7 @@ def _canonical() -> Canonical:
     flag_count = sum(
         1
         for name in Settings.model_fields
-        if name.startswith("KI_V5_") or name.startswith("CORTEX_V5_")
+        if name.startswith(("KI_V5_", "CORTEX_V5_"))
     )
 
     return Canonical(

--- a/v4/tests/test_aci_v0.py
+++ b/v4/tests/test_aci_v0.py
@@ -66,7 +66,7 @@ def test_window_no_truncation_returns_none_cursor():
 
 def test_window_char_cap_drops_whole_lines():
     body = "\n".join("x" * 50 for _ in range(10))  # 10 lines, ~509 chars
-    trimmed, total, shown, cursor = window(body, max_lines=100, max_chars=120)
+    trimmed, _total, shown, cursor = window(body, max_lines=100, max_chars=120)
     assert len(trimmed) <= 120
     assert shown < 10
     assert cursor == shown  # more remains
@@ -74,7 +74,7 @@ def test_window_char_cap_drops_whole_lines():
 
 def test_window_single_overlong_line_hardcut_at_offset_zero():
     body = "A" * 500  # one line longer than the cap
-    trimmed, total, shown, cursor = window(body, max_lines=100, max_chars=100)
+    trimmed, _total, shown, cursor = window(body, max_lines=100, max_chars=100)
     assert trimmed == "A" * 100
     assert shown == 1 and cursor is None
 
@@ -83,7 +83,7 @@ def test_window_single_overlong_line_hardcuts_the_offset_line_not_the_head():
     # Regression: paginating into an over-long line must return THAT line's head,
     # not the document head. Line 0 is short; line 1 exceeds the cap.
     body = "short\n" + "B" * 500
-    trimmed, total, shown, cursor = window(body, max_lines=1, max_chars=100, offset=1)
+    trimmed, _total, shown, cursor = window(body, max_lines=1, max_chars=100, offset=1)
     assert trimmed == "B" * 100          # the offset line, not "short…"
     assert "short" not in trimmed
     assert shown == 1 and cursor is None

--- a/v4/tests/test_cli_version.py
+++ b/v4/tests/test_cli_version.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import re
 
 import pytest
-
 from app.cli import __version__, main
 
 

--- a/v4/tests/test_injected_config_invariant.py
+++ b/v4/tests/test_injected_config_invariant.py
@@ -100,8 +100,16 @@ def test_widened_annotation_silently_loses_the_config() -> None:
     """
     seen: dict[str, object] = {}
 
+    # The spelling here is load-bearing and must stay `Optional[RunnableConfig]`.
+    # `ruff --select UP045 --fix` rewrites it to `RunnableConfig | None`, and this
+    # test still passes — because neither spelling is in langchain_core's match
+    # list, so the canary goes on reporting `None` either way. The autofix would
+    # therefore leave a green suite that no longer exercises the exact form
+    # AGENTS.md invariant #6 forbids. Same reason the suppression exists on
+    # app/agent/nodes/coordinator.py. (Spelling a directive out in prose makes
+    # ruff parse it as a real one, so it is described rather than written here.)
     @tool
-    def probe(q: str, config: Annotated[Optional[RunnableConfig], InjectedToolArg] = None) -> str:
+    def probe(q: str, config: Annotated[Optional[RunnableConfig], InjectedToolArg] = None) -> str:  # noqa: UP045
         """Canary tool using the forbidden widened annotation."""
         seen["config"] = config
         return "ok"

--- a/v4/tests/test_kg.py
+++ b/v4/tests/test_kg.py
@@ -100,7 +100,7 @@ class TestOpenEdge:
     async def test_inserts_when_no_open_edge(self, pool):
         await kg.open_edge("c1", "src-1", "runs_on", "dst-1", {"w": 1}, source_id="ep-9")
         assert len(_edge_inserts(pool)) == 1
-        _, sql, args = _edge_inserts(pool)[0]
+        _, _sql, args = _edge_inserts(pool)[0]
         assert args[:4] == ("c1", "src-1", "runs_on", "dst-1")
         assert json.loads(args[4]) == {"w": 1}
         # P2: trailing valid_from param; None when bitemporal off ⇒ SQL COALESCE → now()

--- a/v4/tests/test_kubectl_tool.py
+++ b/v4/tests/test_kubectl_tool.py
@@ -134,7 +134,7 @@ class TestRiskClassification:
     def test_dry_run_skips_hitl(self):
         """--dry-run commands must not trigger the interrupt."""
         proc = MagicMock(); proc.stdout = "dry-run ok"; proc.stderr = ""
-        with patch("subprocess.run", return_value=proc) as mock_run:
+        with patch("subprocess.run", return_value=proc):
             with patch("app.tools.kubectl_tool.interrupt") as mock_intr:
                 from app.tools.kubectl_tool import run_kubectl
                 run_kubectl.invoke({"command": "kubectl apply -f - --dry-run=client"})

--- a/v4/tests/test_loki_telemetry.py
+++ b/v4/tests/test_loki_telemetry.py
@@ -242,12 +242,12 @@ class TestParseLogLine:
         assert fields["session_id"] == "s1"
 
     def test_plain_error_line(self):
-        level, msg, fields = _parse_log_line("ERROR something went wrong")
+        level, _msg, fields = _parse_log_line("ERROR something went wrong")
         assert level == "ERROR"
         assert fields == {}
 
     def test_plain_info_line(self):
-        level, msg, fields = _parse_log_line("coordinator: routing_decision route=direct")
+        level, _msg, _fields = _parse_log_line("coordinator: routing_decision route=direct")
         assert level == "INFO"
 
     def test_json_uses_levelname_fallback(self):

--- a/v4/tests/test_memory_hierarchy.py
+++ b/v4/tests/test_memory_hierarchy.py
@@ -183,7 +183,7 @@ class TestConsolidation:
         mocker.patch.object(service, "_pool", pool)
         created = await consolidation._propose_detector_candidates()
         assert created == 1
-        insert = [c for c in pool.calls if c[0] == "execute"][0]
+        insert = next(c for c in pool.calls if c[0] == "execute")
         assert "INSERT INTO detectors" in insert[1]
         assert "learned:playbook=CrashLoopBackOff" in str(insert[2])
 

--- a/v4/tests/test_nl_detector_authoring.py
+++ b/v4/tests/test_nl_detector_authoring.py
@@ -9,7 +9,6 @@ import json
 import time
 
 from app.detectors import authoring, review
-from app.detectors import engine as engine_mod
 from app.detectors.engine import DetectorEngine, load_db_detectors
 from app.detectors.models import parse_detect_block
 from app.memory import service

--- a/v4/tests/test_opsmembench.py
+++ b/v4/tests/test_opsmembench.py
@@ -14,8 +14,8 @@ from app.eval.opsmembench import (
 
 
 def _harness(**kw):
-    base = dict(model="m", max_gather_rounds=8, tool_surface="aci-v0",
-                memory_flags=("MEMORY_HYBRID_RETRIEVAL",), replay_fidelity="full", seed=1)
+    base = {"model": "m", "max_gather_rounds": 8, "tool_surface": "aci-v0",
+                "memory_flags": ("MEMORY_HYBRID_RETRIEVAL",), "replay_fidelity": "full", "seed": 1}
     base.update(kw)
     return HarnessSpec(**base)
 

--- a/v4/tests/test_predictive_detection.py
+++ b/v4/tests/test_predictive_detection.py
@@ -43,18 +43,18 @@ class TestProjectEta:
 
     def test_flat_series_does_not_project(self):
         samples = [(i * 60, 0.5) for i in range(11)]
-        eta, r2 = project_eta(samples, threshold=1.0, direction="rising", min_r2=0.6)
+        eta, _r2 = project_eta(samples, threshold=1.0, direction="rising", min_r2=0.6)
         assert eta is None
 
     def test_noisy_below_min_r2_does_not_project(self):
         samples = [(0, 0.5), (60, 0.9), (120, 0.4), (180, 0.95), (240, 0.45)]
-        eta, r2 = project_eta(samples, threshold=1.0, direction="rising", min_r2=0.6)
+        eta, _r2 = project_eta(samples, threshold=1.0, direction="rising", min_r2=0.6)
         assert eta is None
 
     def test_falling_series_toward_floor(self):
         # disk free falling: 1.0 → 0.4 over 600s ; to reach 0.1 floor
         samples = [(i * 60, 1.0 - 0.001 * i * 60) for i in range(11)]
-        eta, r2 = project_eta(samples, threshold=0.1, direction="falling", min_r2=0.6)
+        eta, _r2 = project_eta(samples, threshold=0.1, direction="falling", min_r2=0.6)
         assert eta is not None and eta > 0
 
     def test_rising_away_from_threshold_does_not_fire(self):

--- a/v4/tests/test_readiness.py
+++ b/v4/tests/test_readiness.py
@@ -19,11 +19,10 @@ simultaneously when that database blips, converting degradation into a total out
 from __future__ import annotations
 
 import pytest
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
-
 from app.api.v1.endpoints.health import router as health_router
 from app.core import readiness
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 
 @pytest.fixture
@@ -67,7 +66,7 @@ class TestReadyz:
     def test_readyz_does_not_touch_the_database(self, client, monkeypatch):
         """Deliberate non-dependency: if this ever starts probing Postgres, a DB blip empties
         the Service of endpoints everywhere at once."""
-        import app.db.audit as audit
+        from app.db import audit
 
         def _boom(*_a, **_kw):  # pragma: no cover - must never be called
             raise AssertionError("/readyz consulted the database")


### PR DESCRIPTION
Advances #75.

## Result

| | before | after |
|---|---|---|
| `ruff@latest check v4` | 362 | **210** |
| server suite | 1047 | 1047 passed |
| kube-q suite | 317 | 317 passed |
| mypy | 0 | 0 errors / 134 files |
| pinned ruff gate | clean | clean |

Cleared: `UP045` `UP006` `UP035` `UP037` `I001` `PIE810` `RUF059` `RUF012` `FURB162` `FURB188` `RUF015` `SIM102` `SIM113` `SIM114` `C408` `F401` `F841` `ISC004` `PLR0124`.

## The reason this could not be a blanket `ruff --fix`

`ruff --select UP045 --fix` rewrites the canary in `tests/test_injected_config_invariant.py`:

```diff
-def probe(q: str, config: Annotated[Optional[RunnableConfig], InjectedToolArg] = None) -> str:
+def probe(q: str, config: Annotated[RunnableConfig | None, InjectedToolArg] = None) -> str:
```

**and the suite still reports `8 passed`.**

That test is the negative control for AGENTS.md invariant #6 — it asserts the *forbidden widened form* is never injected. Neither spelling is in langchain_core's match list, so the canary reports `None` either way. The autofix therefore leaves a green test that no longer exercises the form it exists to forbid. Nothing fails; the guard just quietly stops guarding.

I verified this by running ruff's own autofix against that file and re-running the suite, not by reading the rule. The line now carries a suppression and the reasoning, matching the existing one on `app/agent/nodes/coordinator.py` — where the same rewrite would silently stop the run config being injected and take `user_role` and `hitl_bypass` with it.

(Small side-effect worth knowing: writing a suppression directive *in prose* inside a comment makes ruff parse it as a real, malformed directive. The comment describes it instead.)

## Unsafe fixes were reviewed, not trusted

`--unsafe-fixes` was applied to a named subset only, and the diff read by hand. Two hunks needed checking:

- **`SIM114`** merged two `elif` arms into `A or not B`. Confirmed both bodies were `sessions.add(episode)`, so equivalent.
- **`FURB162`** dropped `.replace("Z", "+00:00")` before `fromisoformat`. Safe — `fromisoformat` handles `Z` from 3.11 and `requires-python` is `>=3.12`.

No `# type: ignore` comment was detached — the failure mode called out in #77.

## One real bug fixed in passing

`ki_protocol/events.py` caught `(ValidationError, Exception)`, which is exactly `except Exception` because `ValidationError` is a subclass. The tuple changed nothing and made the intent read narrower than it was. The breadth is deliberate for that decoder, so it now says so plainly.

## The pin stays — and that is a decision for you

What remains is **141 `BLE001`** and **30 `PLW1510`**, and neither is cleanup:

- `BLE001` sites are overwhelmingly deliberate boundary handlers — CLI commands doing `except Exception as exc: console.print(...); return 1`. That is the correct pattern at a CLI boundary, not a defect.
- `PLW1510` is `subprocess.run` without an explicit `check=`. The behaviour-preserving fix is to write `check=False` at all 30 sites. Worth noting it overlaps #140/#139: `_run_kubectl_snapshot` never checks `returncode`, which is a genuine false-all-clear rather than a style issue.

So lifting the pin now means either fixing 141 deliberate handlers, or adding a documented `ignore` for `BLE001`. That trades a version pin for a rule ignore, which is only an improvement if the ignore is narrow and justified — a project-wide call I would rather you make than assume. Options laid out in #75.