### PR TITLE
ci: run the frozen arms' test suites — v2's could not run at all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,9 +120,23 @@ jobs:
         include:
           - suite: server
             workdir: v4
+            syncdir: v4
             path: tests/
           - suite: kube-q CLI
             workdir: v4/packages/kube-q
+            syncdir: v4
+            path: tests/
+          # The frozen arms (ADR-001/002). They are not developed any more,
+          # but shared fixes still land in them — the UTF-8 loader fix did —
+          # and until now nothing ran their regression tests. Each resolves
+          # from its own lockfile, not the v4 workspace. See #155.
+          - suite: v2 · frozen
+            workdir: v2
+            syncdir: v2
+            path: tests/
+          - suite: v3 · frozen
+            workdir: v3
+            syncdir: v3
             path: tests/
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -134,10 +148,11 @@ jobs:
       - name: Install uv
         run: pip install "uv==${UV_VERSION}"
 
-      # Both suites resolve from the v4 workspace root; the two `tests` packages
-      # collide under a single pytest invocation, so they run as separate jobs.
+      # The two v4 suites resolve from the v4 workspace root; their `tests`
+      # packages collide under a single pytest invocation, so every suite
+      # runs as its own job with its own resolution root.
       - name: Sync dependencies
-        working-directory: v4
+        working-directory: ${{ matrix.syncdir }}
         run: uv sync
 
       - name: Run pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   instead of contradicting it.
 
 ### Added
+- **CI now runs the frozen arms' test suites** — `Tests (v2 · frozen)` and `Tests (v3 · frozen)`
+  (#155). The frozen generations are not developed any more, but shared fixes still land in them
+  (the UTF-8 playbook-loader fix did, in both), and nothing in CI had ever run their regression
+  tests. Each arm resolves from its own lockfile rather than the v4 workspace.
+
+  Fixing the gate exposed that **v2's suite could not run at all** — for anyone, including on a
+  maintainer's own machine. Five test modules import `evaluation/`, the offline scoring harness
+  that produced the campaign numbers; it is deliberately not part of this repository, so on any
+  clone those imports fail. Four of them fail at *module scope*, which does not break four
+  modules — it aborts collection for the **whole suite**, so the other thirteen never ran either.
+  Guarding the five with `pytest.importorskip` takes v2 from `4 errors during collection`,
+  **0 tests run**, to **259 passed, 5 skipped**. The guard is conditional, not a deletion: where
+  the harness is present, all five modules still run.
+
 - **CI now gates the demo front-end** (`Web (lint + build)`). `v4/packages/kube-q/web` had no
   gate of any kind: every existing job is scoped to the Python tree, so nothing in CI had ever
   run `npm ci`, `eslint` or `next build`. The gap was not theoretical — the eslint 9 → 10 bump

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,7 +194,19 @@ uv run python -m pytest tests/ -q                              # server (~990 te
 cd packages/kube-q && uv run python -m pytest tests/ -q        # kq CLI (~312 tests)
 ```
 
-CI runs those two test suites **twice** — on Python 3.12 and on Python 3.13. 3.13 is not
+If you are fixing a bug in a frozen arm, run that arm's own suite too — it resolves from its
+own lockfile, not the v4 workspace, so it needs its own sync:
+
+```bash
+cd v2 && uv sync && uv run python -m pytest tests/ -q   # ~259 tests, 5 skipped
+cd v3 && uv sync && uv run python -m pytest tests/ -q   # ~154 tests
+```
+
+The five skips in v2 are expected. Those modules test `evaluation/`, the offline scoring
+harness behind the campaign numbers in the papers; it is not part of this repository, so they
+skip with a reason rather than failing. Nothing you can change in `v2/` will unskip them.
+
+CI runs the two v4 test suites **twice** — on Python 3.12 and on Python 3.13. 3.13 is not
 optional coverage: `v4/Dockerfile`'s runtime stage is `python:3.13-slim`, so it is the
 interpreter the shipped container executes. If your change passes on one and fails on the
 other, that difference is the bug.

--- a/v2/tests/test_aggregate.py
+++ b/v2/tests/test_aggregate.py
@@ -3,8 +3,22 @@ from __future__ import annotations
 
 import pytest
 
-from evaluation.models import AgentTelemetry, SignalScores, TraceIssue
-from evaluation.scorers.aggregate import WEIGHTS, WEIGHTS_WITH_VERIFY, aggregate
+# `evaluation/` is the offline scoring harness that produced the campaign numbers
+# in the papers. It is deliberately not part of this repository (dropped in
+# cb3dd1c) — the artifacts it carries are published on request, not shipped — so
+# on any clone the imports below cannot resolve. Because they run at module
+# scope, that was not one broken module: pytest aborted collection for the WHOLE
+# v2 suite, so the other 13 modules never ran either, on a clone *or* here (the
+# harness sits at the repo root, and `make test` runs from `v2/`). Skip this
+# module when the harness is absent so the rest of the suite is runnable and CI
+# can guard it. See #155.
+pytest.importorskip(
+    "evaluation",
+    reason="needs the out-of-tree `evaluation/` scoring harness",
+)
+
+from evaluation.models import AgentTelemetry, SignalScores, TraceIssue  # noqa: E402
+from evaluation.scorers.aggregate import WEIGHTS, WEIGHTS_WITH_VERIFY, aggregate  # noqa: E402
 
 
 # ── Weight invariants ─────────────────────────────────────────────────────────

--- a/v2/tests/test_compare.py
+++ b/v2/tests/test_compare.py
@@ -3,6 +3,16 @@ import json
 from pathlib import Path
 import pytest
 
+# Every test below defers `from evaluation.compare import ...` into the function
+# body. That kept collection alive, but only moved the failure: without the
+# out-of-tree `evaluation/` harness all 12 turned into runtime errors instead.
+# Skip the module outright for the same reason as the other harness-dependent
+# suites here. See #155.
+pytest.importorskip(
+    "evaluation.compare",
+    reason="needs the out-of-tree `evaluation/` scoring harness",
+)
+
 
 def _make_run_dir(tmp_path: Path, target: str, records: list[dict]) -> Path:
     run_dir = tmp_path / f"{target}_20260501_120000"

--- a/v2/tests/test_follow_up.py
+++ b/v2/tests/test_follow_up.py
@@ -1,7 +1,23 @@
 """Tests for `evaluation.follow_up.agent_self_gated`."""
 from __future__ import annotations
 
-from evaluation.follow_up import DEFAULT_FOLLOW_UP, agent_self_gated
+import pytest
+
+# `evaluation/` is the offline scoring harness that produced the campaign numbers
+# in the papers. It is deliberately not part of this repository (dropped in
+# cb3dd1c) — the artifacts it carries are published on request, not shipped — so
+# on any clone the imports below cannot resolve. Because they run at module
+# scope, that was not one broken module: pytest aborted collection for the WHOLE
+# v2 suite, so the other 13 modules never ran either, on a clone *or* here (the
+# harness sits at the repo root, and `make test` runs from `v2/`). Skip this
+# module when the harness is absent so the rest of the suite is runnable and CI
+# can guard it. See #155.
+pytest.importorskip(
+    "evaluation",
+    reason="needs the out-of-tree `evaluation/` scoring harness",
+)
+
+from evaluation.follow_up import DEFAULT_FOLLOW_UP, agent_self_gated  # noqa: E402
 
 
 def test_default_text() -> None:

--- a/v2/tests/test_loki_telemetry.py
+++ b/v2/tests/test_loki_telemetry.py
@@ -5,8 +5,22 @@ import json
 
 import pytest
 
-from evaluation.models import LokiLogLine, LokiLogs
-from evaluation.collectors.loki_collector import parse_telemetry, _parse_log_line
+# `evaluation/` is the offline scoring harness that produced the campaign numbers
+# in the papers. It is deliberately not part of this repository (dropped in
+# cb3dd1c) — the artifacts it carries are published on request, not shipped — so
+# on any clone the imports below cannot resolve. Because they run at module
+# scope, that was not one broken module: pytest aborted collection for the WHOLE
+# v2 suite, so the other 13 modules never ran either, on a clone *or* here (the
+# harness sits at the repo root, and `make test` runs from `v2/`). Skip this
+# module when the harness is absent so the rest of the suite is runnable and CI
+# can guard it. See #155.
+pytest.importorskip(
+    "evaluation",
+    reason="needs the out-of-tree `evaluation/` scoring harness",
+)
+
+from evaluation.models import LokiLogLine, LokiLogs  # noqa: E402
+from evaluation.collectors.loki_collector import parse_telemetry, _parse_log_line  # noqa: E402
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────

--- a/v2/tests/test_signal_scorer.py
+++ b/v2/tests/test_signal_scorer.py
@@ -3,7 +3,21 @@ from __future__ import annotations
 
 import pytest
 
-from evaluation.models import EvalResult, LangfuseTrace, LokiLogs, LokiLogLine
+# `evaluation/` is the offline scoring harness that produced the campaign numbers
+# in the papers. It is deliberately not part of this repository (dropped in
+# cb3dd1c) — the artifacts it carries are published on request, not shipped — so
+# on any clone the imports below cannot resolve. Because they run at module
+# scope, that was not one broken module: pytest aborted collection for the WHOLE
+# v2 suite, so the other 13 modules never ran either, on a clone *or* here (the
+# harness sits at the repo root, and `make test` runs from `v2/`). Skip this
+# module when the harness is absent so the rest of the suite is runnable and CI
+# can guard it. See #155.
+pytest.importorskip(
+    "evaluation",
+    reason="needs the out-of-tree `evaluation/` scoring harness",
+)
+
+from evaluation.models import EvalResult, LangfuseTrace, LokiLogs, LokiLogLine  # noqa: E402
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #155.

#155 asked whether v2/v3 resolve their own dependencies or lean on the v4 workspace. They resolve their own — each has its own `pyproject.toml` and `uv.lock`. But answering that turned up a bigger problem than the one the issue describes.

## v2's suite has been unrunnable since `cb3dd1c` — for everyone

Five v2 test modules import `evaluation/`, the offline scoring harness behind the campaign numbers in the papers. It is deliberately not part of this repository, so those imports cannot resolve on a clone.

Four import at **module scope**. That does not break four modules — pytest aborts collection for the *whole suite*:

```
ERROR tests/test_aggregate.py       ModuleNotFoundError: No module named 'evaluation'
ERROR tests/test_follow_up.py
ERROR tests/test_loki_telemetry.py
ERROR tests/test_signal_scorer.py
!!!! Interrupted: 4 errors during collection !!!!
2 warnings, 4 errors in 3.46s      # exit 2 — 0 tests run
```

The other thirteen modules never ran either. The fifth module, `test_compare.py`, defers its imports into the test bodies — that kept collection alive but only moved the failure, turning all twelve of its tests into runtime errors.

**This is not a clone-only problem.** The harness sits at the repo root while `make test` runs from `v2/`, so the documented command fails identically on a maintainer's own machine. That is why it went unnoticed: the suite reports an error, not a failure, and nothing in CI looked.

## Fix

`pytest.importorskip` on the five, rather than deleting them:

| | before | after |
|---|---|---|
| `cd v2 && uv run python -m pytest tests/ -q` | `4 errors during collection`, **0 tests run**, exit 2 | **259 passed, 5 skipped**, exit 0 |

The guard is conditional, which matters — it is not a quiet delete. Re-run with the harness importable and all five modules run, with zero skips:

```
1 failed, 356 passed        # 356 vs 259 — the guard lets them through when present
```

(That one failure is pre-existing and out of scope here — see below.)

`v3` needed no changes at all: **154 passed** standalone, exit 0.

## CI

Two new matrix entries on the existing `test` job — `Tests (v2 · frozen)` and `Tests (v3 · frozen)`. The sync step was hardcoded to `v4`; since the frozen arms resolve from their own lockfiles it becomes `matrix.syncdir`. The two v4 entries keep `syncdir: v4`, so **`Tests (server)` and `Tests (kube-q CLI)` keep their exact check names** and branch protection is unaffected.

`CONTRIBUTING.md` gets the per-arm commands and an explanation of why the five skips are expected — `CONTRIBUTING.md` invites bug fixes to `v2/`–`v3/`, and until now anyone accepting that invitation hit `4 errors during collection` with nothing to explain it.

## Verification

Run against the exact CI commands, on Python 3.12 (the version the job pins), from a tree without the harness — i.e. what a fresh clone sees:

```
v2  uv sync -p 3.12          exit 0
    uv run python -m pytest tests/ -q     259 passed, 5 skipped     exit 0
v3  uv sync -p 3.12          exit 0
    uv run python -m pytest tests/ -q     154 passed                exit 0
```

And the thing #155 was actually about — the UTF-8 playbook-loader fix landed in both frozen arms with a regression test in each, and neither had ever been executed:

```
v2  -k 'utf8'    1 passed, 5 skipped, 258 deselected     # first execution ever
v3  -k 'utf8'    1 passed, 153 deselected
```

YAML validated with `yaml.safe_load`; job list unchanged apart from the new matrix entries.

## Two follow-ups, deliberately not in this PR

1. **The new checks are not required checks.** Adding a job does not add it to branch protection — that is a repo-settings change and needs a maintainer to make it.
2. **`test_compare.py::test_compute_rqb_table_averages` fails when the harness *is* present.** It is a stale assertion, not a regression: the harness moved to `judge_total >= 28` ("matching `judge.PASS_THRESHOLD`, was a strict `> 28`") and the test still encodes the old strict form, with a comment asserting `28.0 itself does not pass`. It could never have been caught, because the test could not run. It touches a paper-adjacent threshold, so it is left for a maintainer call rather than changed here.
