### PR TITLE
feat(ci): gate the contributor rosters against each other

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,12 @@ jobs:
       - name: Check text-mode calls name an encoding
         run: ./scripts/check-text-encoding.py
 
+      # Rides in this job on purpose. Branch protection matches required checks
+      # BY NAME, so a new job name would be missing from the required list and
+      # every open PR would sit unmergeable until the settings caught up. See #167.
+      - name: Check the contributor rosters agree
+        run: ./scripts/check-contributor-roster.py
+
   types:
     name: Types (mypy)
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ uv sync          # creates .venv and installs the whole workspace
 
 ## Gate commands — these are exactly what CI runs
 
-From the repo root, `make setup` runs all six gates in order. Individually, from `v4/`:
+From the repo root, `make setup` runs all eight gates in order. Individually, from `v4/`:
 
 ```bash
 # 1. Lint — `ruff check` only. NOT `ruff format`.
@@ -59,14 +59,17 @@ uv run ruff check packages/kubeintellect-server/app/ packages/ki-protocol/
 # 2. Types — the workspace is at ZERO errors; keep it there.
 uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube-q/kube_q
 
-# 3. Server suite (1059 tests)
+# 3. Server suite (1068 tests)
 uv run python -m pytest tests/ -q
 
 # 4. kq CLI suite (317 tests)
 cd packages/kube-q && uv run python -m pytest tests/ -q
 ```
 
-Plus two repo-root gates, which need no virtualenv:
+Plus four repo-root gates, which need no virtualenv. Gates 7 and 8 run inside the CI job
+named **Syntax warnings** rather than jobs of their own — branch protection matches required
+checks by name, so a new job name is a check `main` does not require and every open PR would
+sit unmergeable until the settings caught up:
 
 ```bash
 # 5. File modes — a tracked file is executable if and only if it has a shebang.
@@ -75,6 +78,12 @@ make fix-modes            # corrects any violation in place
 
 # 6. Syntax — every tracked .py outside v1-v3 compiles with no SyntaxWarning.
 make check-syntax         # or: ./scripts/check-syntax-warnings.py
+
+# 7. Encoding — every text-mode read/write names an encoding (#136/#156).
+make check-encoding       # or: ./scripts/check-text-encoding.py
+
+# 8. Roster — .all-contributorsrc and the README table name the same people (#167).
+make check-roster         # or: ./scripts/check-contributor-roster.py
 ```
 
 If you create a file, do not mark it executable unless it is a script with a shebang. This

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **A gate now keeps the two contributor rosters in sync** (#167).
+  `.all-contributorsrc` and the **Contributors** table in `README.md` are both hand-maintained,
+  nothing compared them, and they had drifted: 5 people on one side, 8 on the other, and one
+  contributor on neither. `scripts/check-contributor-roster.py` fails naming exactly which
+  handles are missing from which surface, plus a person listed twice or spelled two ways.
+
+  It refuses to pass on an **empty** read. A comparison that quietly stops seeing rows — a
+  renamed heading, a changed row format — would otherwise compare two empty sets and report
+  green forever, which is how this repo has lost a guard before.
+
+  `make check-roster`, and a step inside the existing **Syntax warnings** CI job. It joins that
+  job rather than adding one of its own on purpose: branch protection matches required checks by
+  name, so a new job name is a check `main` does not require, and every open PR would sit
+  unmergeable until the settings caught up.
+
+  Two related gaps closed while wiring it: `scripts/dev-setup.sh` never ran the encoding gate
+  added in #161, and `make check-encoding` was missing from `.PHONY` and from `make help`.
+  Contributor setup now runs eight gates, not six, and `AGENTS.md`, `CONTRIBUTING.md` and
+  `TRIAGE.md` say so.
+
 ### Changed
 - **The contributor roster now names everyone who has contributed.** `.all-contributorsrc`
   listed 5 people while the README credited 8, and one contributor —

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,8 +52,8 @@ make setup          # or: ./scripts/dev-setup.sh
 ```
 
 That installs [`uv`](https://docs.astral.sh/uv/) if missing, installs the whole `v4`
-workspace, and then runs **the exact six gates CI runs** (ruff, mypy, both test suites, file
-modes, syntax warnings) so you know your environment is correct before you change anything. It
+workspace, and then runs **the exact eight gates CI runs** (ruff, mypy, both test suites, file
+modes, syntax warnings, text encoding, contributor roster) so you know your environment is correct before you change anything. It
 takes about a minute and prints what to do next.
 
 **Zero-install alternative:** open the repo in a

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # All versions share ONE Langfuse project; each tags its traces with version:vN, so
 # per-version cost is a tag filter (per-version projects need Langfuse Enterprise).
 # ═══════════════════════════════════════════════════════════════════════════════
-.PHONY: help setup check-modes fix-modes check-syntax kind-cluster-create kind-cluster-create-vm kind-cluster-stop kind-cluster-start \
+.PHONY: help setup check-modes fix-modes check-syntax check-encoding check-roster kind-cluster-create kind-cluster-create-vm kind-cluster-stop kind-cluster-start \
         kind-cluster-cleanup monitoring-install monitoring-uninstall \
         langfuse-provision langfuse-install langfuse-clean hosts-entry helm-package \
         opsmembench opsmembench-demo opsmembench-driver-check opsmembench-test
@@ -23,10 +23,12 @@ help: ## Show shared-infra targets
 	@printf "Defaults: KIND_CLUSTER_NAME=\033[33m$(KIND_CLUSTER_NAME)\033[0m  MONITORING_NS=\033[33m$(MONITORING_NS)\033[0m\n"
 	@printf "Per-version app targets live in vN/Makefile — e.g. \033[36mcd v4 && make kind-deploy-kubeintellect\033[0m\n"
 	@printf "\n\033[1mContributors — start here (no cluster needed)\033[0m\n"
-	@printf "  \033[36msetup\033[0m                   Install the v4 workspace and run all six CI gates\n"
+	@printf "  \033[36msetup\033[0m                   Install the v4 workspace and run all eight CI gates\n"
 	@printf "  \033[36mcheck-modes\033[0m             Check the CI file-mode gate (executable iff shebang)\n"
 	@printf "  \033[36mfix-modes\033[0m               Fix any file-mode violations in place\n"
 	@printf "  \033[36mcheck-syntax\033[0m            Check the CI syntax gate (no SyntaxWarning on 3.13)\n"
+	@printf "  \033[36mcheck-encoding\033[0m           Check the CI encoding gate (every text-mode call names one)\n"
+	@printf "  \033[36mcheck-roster\033[0m             Check the CI roster gate (both contributor lists agree)\n"
 	@printf "\n\033[1mKind cluster (one cluster, shared by all versions)\033[0m\n"
 	@printf "  \033[36mkind-cluster-create\033[0m      Create the shared Kind cluster (run once)\n"
 	@printf "  \033[36mkind-cluster-create-vm\033[0m   Create Kind cluster on an Azure VM (run once on the VM)\n"
@@ -64,6 +66,9 @@ check-syntax: ## Check the syntax CI gate — no SyntaxWarning on the newest sup
 
 check-encoding: ## Check the encoding CI gate — every text-mode read/write names its encoding
 	@./scripts/check-text-encoding.py
+
+check-roster: ## Check the roster CI gate — .all-contributorsrc and the README table name the same people
+	@./scripts/check-contributor-roster.py
 
 kind-cluster-create: ## Create the shared Kind cluster (2-node, hot-reload mounts) — run once
 	KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) bash scripts/kind/create-kind-cluster.sh

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -117,7 +117,7 @@ welcome rather than rude — it is a backlog, not a rejection.
 
   | Check | Runs locally? |
   |---|---|
-  | `Lint (ruff)` · `Types (mypy)` · `Tests (server)` · `Tests (kube-q CLI)` · `File modes` · `Syntax warnings` | ✅ `make setup` runs all six |
+  | `Lint (ruff)` · `Types (mypy)` · `Tests (server)` · `Tests (kube-q CLI)` · `File modes` · `Syntax warnings` | ✅ `make setup` runs all six (plus the encoding + roster gates that ride inside `Syntax warnings`) |
   | `Install smoke test` · `Tests (server · py3.13)` · `Tests (kube-q CLI · py3.13)` | ❌ CI only |
 
   So a green `make setup` covers six of the nine. If your PR is red on one of the

--- a/scripts/check-contributor-roster.py
+++ b/scripts/check-contributor-roster.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# ─────────────────────────────────────────────────────────────────────────────
+# check-contributor-roster.py — the two contributor rosters name the same people.
+#
+# WHY THIS EXISTS
+#
+# Recognition lives on TWO surfaces in this repo:
+#
+#   * .all-contributorsrc — machine-readable, the All Contributors spec
+#   * the "### Contributors" table in README.md — the one humans actually read
+#
+# Nothing compared them, and by 2026-08-22 they disagreed: the rc file listed 5
+# people, the README credited 8, and @Chris7717 was on NEITHER despite a merged
+# playbook (#114) and the report (#115) that found the .gitignore glob keeping
+# .env.example out of every clone.
+#
+# That failed quietly for weeks, and quietly is the whole problem. Prose credit
+# is what people see, so missing rc entries are invisible; and a person missing
+# from both surfaces is invisible everywhere. A contributor never learns they
+# were dropped — they just are. See #167.
+#
+# Like check-syntax-warnings.py, check-file-modes.sh and check-text-encoding.py,
+# this is deliberately stdlib only: no virtualenv, no network, and independent
+# of ruff and of the <0.16 pin in v4/pyproject.toml.
+#
+# WHAT IT CHECKS
+#
+#   1. Every login in .all-contributorsrc has a row in the README table.
+#   2. Every @handle in the README table has an .all-contributorsrc entry.
+#   3. Neither surface lists the same person twice.
+#   4. The same person is spelled the same way on both (GitHub resolves logins
+#      case-insensitively, so a case-only mismatch still links — it is drift
+#      between two hand-maintained files, and it is how a later exact-match
+#      script starts reporting a person who is right there).
+#   5. NEITHER SURFACE IS EMPTY. A gate that reads nothing and compares two
+#      empty sets passes forever while guarding nothing — this repo has already
+#      lost a guard exactly that way (a `ruff --fix` rewrote a canary and the
+#      suite still said green). An empty read is a failure here, not a pass.
+#
+# It does NOT check contribution *types*: whether someone credited for `doc`
+# should also carry `test` is a judgement call, not drift.
+# ─────────────────────────────────────────────────────────────────────────────
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Anchored to the exact row shape the README table uses:
+#     | **[@handle](https://github.com/handle)** | what they did |
+# Anchoring rather than matching any @mention is the point: a handle named in
+# the surrounding prose is not a row in the credit table.
+ROW = re.compile(r"^\| \*\*\[@([^\]]+)\]", re.M)
+
+# The table lives under this heading. Scoping to the section keeps a future
+# table elsewhere in the README from silently joining the comparison.
+HEADING = re.compile(r"^#{2,4}\s+Contributors\s*$", re.M)
+
+
+def repo_root() -> str:
+    return subprocess.run(  # noqa: S603
+        ["git", "rev-parse", "--show-toplevel"],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def readme_handles(text: str) -> list[str]:
+    """The @handles in the README's Contributors table, in document order.
+
+    Returns them WITH duplicates, so the caller can report a name listed twice.
+    """
+    start = HEADING.search(text)
+    if start is None:
+        return []
+    section = text[start.end() :]
+    # Stop at the next heading of the same or higher level, so only the
+    # Contributors section is read.
+    end = re.search(r"^#{1,4}\s+\S", section, re.M)
+    if end is not None:
+        section = section[: end.start()]
+    return ROW.findall(section)
+
+
+def rc_logins(raw: str) -> list[str]:
+    """The logins in .all-contributorsrc, in file order, duplicates kept."""
+    data = json.loads(raw)
+    return [c["login"] for c in data.get("contributors", [])]
+
+
+def duplicates(names: list[str]) -> list[str]:
+    seen: set[str] = set()
+    dupes: list[str] = []
+    for name in names:
+        key = name.lower()
+        if key in seen and name not in dupes:
+            dupes.append(name)
+        seen.add(key)
+    return dupes
+
+
+def compare(rc: list[str], readme: list[str]) -> list[str]:
+    """Every way the two rosters can disagree, as printable lines."""
+    problems: list[str] = []
+
+    if not rc:
+        problems.append(
+            ".all-contributorsrc lists no contributors at all — the file is empty, "
+            "unparseable, or its shape changed. This gate cannot guard two empty sets."
+        )
+    if not readme:
+        problems.append(
+            "the README Contributors table has no rows this gate can see — the heading "
+            "or the row format changed. Fix ROW/HEADING in this script, or the gate is "
+            "passing while guarding nothing."
+        )
+    if problems:
+        return problems
+
+    for surface, names in ((".all-contributorsrc", rc), ("README.md", readme)):
+        for name in duplicates(names):
+            problems.append(f"{surface} lists @{name} more than once")
+
+    rc_by_key = {n.lower(): n for n in rc}
+    readme_by_key = {n.lower(): n for n in readme}
+
+    for key in sorted(rc_by_key.keys() - readme_by_key.keys()):
+        problems.append(
+            f"@{rc_by_key[key]} is in .all-contributorsrc but has no row in the README table"
+        )
+    for key in sorted(readme_by_key.keys() - rc_by_key.keys()):
+        problems.append(
+            f"@{readme_by_key[key]} has a README row but no .all-contributorsrc entry"
+        )
+    for key in sorted(rc_by_key.keys() & readme_by_key.keys()):
+        if rc_by_key[key] != readme_by_key[key]:
+            problems.append(
+                f"spelled two ways: .all-contributorsrc has @{rc_by_key[key]}, "
+                f"README.md has @{readme_by_key[key]}"
+            )
+
+    return problems
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) == 2:
+        rc_path, readme_path = Path(argv[0]), Path(argv[1])
+    elif argv:
+        print("usage: check-contributor-roster.py [<.all-contributorsrc> <README.md>]")
+        return 2
+    else:
+        root = Path(repo_root())
+        rc_path, readme_path = root / ".all-contributorsrc", root / "README.md"
+
+    try:
+        rc = rc_logins(rc_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        print(f"roster FAILED — cannot read {rc_path}: {exc}")
+        return 1
+    try:
+        readme = readme_handles(readme_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        print(f"roster FAILED — cannot read {readme_path}: {exc}")
+        return 1
+
+    problems = compare(rc, readme)
+    if problems:
+        print(f"{len(problems)} contributor-roster problem(s):\n")
+        for line in problems:
+            print(f"  {line}")
+        print(
+            "\nBoth surfaces must name the same people: .all-contributorsrc is the"
+            "\nmachine-readable record, the README table is what anyone actually reads."
+            "\nSomeone missing from one is under-credited; missing from both is invisible."
+            "\nSee #167."
+        )
+        return 1
+
+    print(f"roster OK — .all-contributorsrc and the README table name the same {len(rc)} contributors")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -42,66 +42,83 @@ uv sync
 ok "workspace installed into v4/.venv"
 
 # ---------------------------------------------------------------------------
-# Run the six gates CI runs. Keep these in lockstep with:
+# Run the eight gates CI runs. Keep these in lockstep with:
 #   .github/workflows/ci.yml, CONTRIBUTING.md, AGENTS.md
 #
-# Gates 1-4 need the virtualenv. Gates 5-6 deliberately do not — see the header
-# comments in the two scripts they call.
+# Gates 1-4 need the virtualenv. Gates 5-8 deliberately do not — see the header
+# comments in the four scripts they call. Gates 7-8 ride inside the CI job
+# named "Syntax warnings", so they add no new required check.
 # ---------------------------------------------------------------------------
 STATUS=0
 
-say "Gate 1/6 — ruff check (this IS the CI lint gate)"
+say "Gate 1/8 — ruff check (this IS the CI lint gate)"
 if uv run ruff check packages/kubeintellect-server/app/ packages/ki-protocol/; then
   ok "lint clean"
 else
   fail "ruff check failed"; STATUS=1
 fi
 
-say "Gate 2/6 — mypy (the workspace sits at zero errors)"
+say "Gate 2/8 — mypy (the workspace sits at zero errors)"
 if uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube-q/kube_q; then
   ok "types clean"
 else
   fail "mypy failed"; STATUS=1
 fi
 
-say "Gate 3/6 — server test suite"
+say "Gate 3/8 — server test suite"
 if uv run python -m pytest tests/ -q; then
   ok "server suite passed"
 else
   fail "server suite failed"; STATUS=1
 fi
 
-say "Gate 4/6 — kq CLI test suite"
+say "Gate 4/8 — kq CLI test suite"
 if (cd packages/kube-q && uv run python -m pytest tests/ -q); then
   ok "kq suite passed"
 else
   fail "kq suite failed"; STATUS=1
 fi
 
-say "Gate 5/6 — file modes (executable iff shebang)"
+say "Gate 5/8 — file modes (executable iff shebang)"
 if (cd "$ROOT" && ./scripts/check-file-modes.sh); then
   ok "file modes clean"
 else
   fail "file-mode check failed"; STATUS=1
 fi
 
-say "Gate 6/6 — syntax warnings"
+say "Gate 6/8 — syntax warnings"
 if (cd "$ROOT" && ./scripts/check-syntax-warnings.py); then
   ok "no syntax warnings"
 else
   fail "syntax-warning check failed"; STATUS=1
 fi
 
+say "Gate 7/8 — text-mode calls name an encoding"
+if (cd "$ROOT" && ./scripts/check-text-encoding.py); then
+  ok "every text-mode call names an encoding"
+else
+  fail "encoding check failed"; STATUS=1
+fi
+
+say "Gate 8/8 — contributor rosters agree"
+if (cd "$ROOT" && ./scripts/check-contributor-roster.py); then
+  ok "both contributor rosters name the same people"
+else
+  fail "roster check failed"; STATUS=1
+fi
+
 echo
 if [ "$STATUS" -eq 0 ]; then
   cat <<'EOF'
 ────────────────────────────────────────────────────────────────────────────
- You are ready to contribute. All six locally-runnable gates pass on a
+ You are ready to contribute. All eight locally-runnable gates pass on a
  clean checkout.
 
- `main` requires NINE checks. Six of them are the gates above. The other
- three run only in CI, because they need a clean machine or another
- interpreter — so a green run here does not guarantee a green PR:
+ `main` requires NINE checks. The eight gates above cover six of them —
+ the encoding and roster gates ride inside the "Syntax warnings" check
+ rather than adding one of their own. The other three run only in CI,
+ because they need a clean machine or another interpreter, so a green run
+ here does not guarantee a green PR:
    • Install smoke test
    • Tests (server · py3.13)
    • Tests (kube-q CLI · py3.13)
@@ -113,9 +130,11 @@ if [ "$STATUS" -eq 0 ]; then
    uv run python -m pytest tests/ -q
    cd packages/kube-q && uv run python -m pytest tests/ -q
 
- …and the two that need no virtualenv, from the repo root:
+ …and the four that need no virtualenv, from the repo root:
    make check-modes
    make check-syntax
+   make check-encoding
+   make check-roster
 
  Heads-up, so you don't chase pre-existing debt that is NOT your bug:
    • `make lint` fails on a clean checkout — it runs `ruff format --check`,

--- a/v4/tests/test_contributor_roster_gate.py
+++ b/v4/tests/test_contributor_roster_gate.py
@@ -1,0 +1,131 @@
+"""Gate: the two contributor rosters name the same people.
+
+Exercises scripts/check-contributor-roster.py, the guard added for #167 — the
+rc file listed 5 people, the README credited 8, and @Chris7717 was on neither.
+
+The red cases carry the weight. A roster comparison that can only pass is worth
+nothing, and the specific way this one could rot is by reading *nothing* from
+one surface and cheerfully comparing two empty sets, so that has a test of its
+own.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check-contributor-roster.py"
+
+_README_TEMPLATE = """\
+# Project
+
+### Contributors
+
+| Person | What they did |
+| --- | --- |
+{rows}
+
+### Something else
+
+| **[@notacontributor](https://github.com/notacontributor)** | a row outside the table |
+"""
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("check_contributor_roster", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _readme(*handles: str) -> str:
+    rows = "\n".join(
+        f"| **[@{h}](https://github.com/{h})** | did a thing |" for h in handles
+    )
+    return _README_TEMPLATE.format(rows=rows)
+
+
+def _rc(*logins: str) -> str:
+    return json.dumps({"contributors": [{"login": lg, "contributions": ["code"]} for lg in logins]})
+
+
+def test_real_rosters_agree():
+    """The live surfaces, which is the thing the CI job actually asserts."""
+    checker = _load_checker()
+    rc = checker.rc_logins((_REPO_ROOT / ".all-contributorsrc").read_text(encoding="utf-8"))
+    readme = checker.readme_handles((_REPO_ROOT / "README.md").read_text(encoding="utf-8"))
+
+    # A vacuous comparison would pass for free — this is the failure mode #167
+    # is about, so assert both surfaces were actually read.
+    assert len(rc) >= 9, f"suspiciously few rc entries: {len(rc)}"
+    assert len(readme) >= 9, f"suspiciously few README rows: {len(readme)}"
+    assert checker.compare(rc, readme) == []
+
+
+def test_missing_from_readme_is_reported_by_name():
+    checker = _load_checker()
+    problems = checker.compare(["alice", "bob"], ["alice"])
+    assert len(problems) == 1
+    assert "@bob" in problems[0]
+    assert "no row in the README table" in problems[0]
+
+
+def test_missing_from_rc_is_reported_by_name():
+    checker = _load_checker()
+    problems = checker.compare(["alice"], ["alice", "bob"])
+    assert len(problems) == 1
+    assert "@bob" in problems[0]
+    assert "no .all-contributorsrc entry" in problems[0]
+
+
+def test_the_historical_drift_would_have_been_caught():
+    """The exact 2026-08-22 state: rc had 5, the README had 8, Chris7717 neither."""
+    checker = _load_checker()
+    rc = ["hariomlohardev", "AdvaitVarhade", "shaurya703", "uuzzrm", "ybayraktarb"]
+    readme = [*rc, "floze-the-genius", "Priyanshu608", "AshSgDe29071999"]
+
+    problems = checker.compare(rc, readme)
+    assert len(problems) == 3
+    assert all("no .all-contributorsrc entry" in p for p in problems)
+    # Chris7717 was on neither surface, so no comparison could have found him.
+    # That is a limit of this gate, recorded here so nobody assumes otherwise.
+    assert not any("Chris7717" in p for p in problems)
+
+
+def test_an_empty_surface_fails_rather_than_passing_vacuously():
+    checker = _load_checker()
+    assert checker.compare([], []) != []
+    assert any("empty" in p or "no contributors" in p for p in checker.compare([], ["alice"]))
+    assert any("guarding nothing" in p for p in checker.compare(["alice"], []))
+
+
+def test_case_only_drift_is_reported():
+    checker = _load_checker()
+    problems = checker.compare(["Alice"], ["alice"])
+    assert len(problems) == 1
+    assert "spelled two ways" in problems[0]
+
+
+def test_a_person_listed_twice_is_reported():
+    checker = _load_checker()
+    problems = checker.compare(["alice", "alice"], ["alice"])
+    assert any("more than once" in p for p in problems)
+
+
+def test_only_the_contributors_section_is_read():
+    """A table row elsewhere in the README is not a credit row."""
+    checker = _load_checker()
+    handles = checker.readme_handles(_readme("alice", "bob"))
+    assert handles == ["alice", "bob"]
+
+
+def test_a_renamed_heading_fails_instead_of_reading_nothing():
+    checker = _load_checker()
+    text = _readme("alice").replace("### Contributors", "### Credits")
+    assert checker.readme_handles(text) == []
+    assert any("guarding nothing" in p for p in checker.compare(["alice"], []))


### PR DESCRIPTION
Closes #167.

`.all-contributorsrc` and the **Contributors** table in `README.md` are both hand-maintained and nothing compared them. They had drifted — 5 people on one side, 8 on the other, and [@Chris7717](https://github.com/Chris7717) on neither, despite a merged playbook (#114) and the report (#115) that found the `.gitignore` glob keeping `.env.example` out of every clone.

It failed **quietly**, for weeks, and that is the whole problem: a contributor never learns they were dropped. They just are.

## The gate

`scripts/check-contributor-roster.py` — stdlib only, like its three siblings, so it stays independent of ruff and of the `<0.16` pin.

It names the drift rather than announcing it:

```
1 contributor-roster problem(s):

  @Chris7717 has a README row but no .all-contributorsrc entry
```

It also catches a person listed **twice**, and the same person **spelled two ways** across the surfaces (GitHub resolves logins case-insensitively, so that still links today — it is drift between two hand-edited files, and it is how a later exact-match script starts reporting someone who is right there).

**It refuses to pass on an empty read.** A comparison that quietly stops seeing rows — a renamed heading, a changed row format — would otherwise compare two empty sets and report green forever. This repo has already lost a guard exactly that way: a `ruff --fix` rewrote an injected-config canary and the suite still said `8 passed`. So an empty surface is a failure here, not a pass, and it has its own test.

## Wiring

`make check-roster`, plus a step inside the **existing `Syntax warnings` CI job**.

Not a job of its own, deliberately: branch protection matches required checks **by name**, so a new job name is a check `main` does not require, and every open PR would sit unmergeable until the settings caught up. The job name is unchanged.

## Two gaps found while wiring it, closed here

- `scripts/dev-setup.sh` never ran the encoding gate added in #161 — contributor setup printed *"All six locally-runnable gates pass"* while skipping one of them. It now runs **eight**, and says which two ride inside `Syntax warnings`.
- `make check-encoding` was in neither `.PHONY` nor `make help`, so it existed but was undiscoverable.

`AGENTS.md`, `CONTRIBUTING.md` and `TRIAGE.md` updated to match.

## Tests — nine, and the red cases carry the weight

A roster comparison that can only pass is worth nothing. Beyond the two directions of drift, the suite covers duplicates, case-only drift, section scoping (a table row elsewhere in the README is not a credit row), a renamed heading, and both empty surfaces.

One test reconstructs the **exact 2026-08-22 state** and asserts the gate would have caught it — and records the limit honestly: @Chris7717 was on *neither* surface, so no comparison could ever have found him. This gate stops the two lists diverging; it cannot invent a person nobody wrote down.

## Verified on this commit

| Gate | Result |
|---|---|
| `./scripts/check-file-modes.sh` | ✅ |
| `./scripts/check-syntax-warnings.py` | ✅ 310 files |
| `./scripts/check-text-encoding.py` | ✅ 310 files |
| `./scripts/check-contributor-roster.py` | ✅ 9 contributors, both sides |
| `ruff check` (CI scope) | ✅ 0 |
| `mypy` | ✅ 0 / 172 files |
| server suite | ✅ **1068 passed** |
| kube-q suite | ✅ **317 passed** |

Red case proven end-to-end, not just at the function level: dropping `Chris7717` from a copy of `.all-contributorsrc` exits **1** with the message above.
