### PR TITLE
fix(encoding): subprocess.run(..., text=True) decoded with the locale encoding too (#168)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ uv run ruff check packages/kubeintellect-server/app/ packages/ki-protocol/
 # 2. Types — the workspace is at ZERO errors; keep it there.
 uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube-q/kube_q
 
-# 3. Server suite (1068 tests)
+# 3. Server suite (1079 tests)
 uv run python -m pytest tests/ -q
 
 # 4. kq CLI suite (317 tests)
@@ -79,7 +79,8 @@ make fix-modes            # corrects any violation in place
 # 6. Syntax — every tracked .py outside v1-v3 compiles with no SyntaxWarning.
 make check-syntax         # or: ./scripts/check-syntax-warnings.py
 
-# 7. Encoding — every text-mode read/write names an encoding (#136/#156).
+# 7. Encoding — every text-mode read, write and subprocess call names an
+#    encoding (#136/#156/#161, and the subprocess half #168).
 make check-encoding       # or: ./scripts/check-text-encoding.py
 
 # 8. Roster — .all-contributorsrc and the README table name the same people (#167).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- **`subprocess.run(..., text=True)` decoded with the locale encoding too** (#168) — the half of
+  the #136/#156 class that #161 left standing. The children here are `kubectl`, `helm` and `git`,
+  whose output carries whatever a user named a resource and whatever a container wrote to its
+  logs, so on Windows or under the POSIX `C` locale a single non-ASCII byte was enough.
+
+  25 call sites named an encoding. The failure was not uniform, which is why the fix is not
+  either: `run_kubectl` catches only `FileNotFoundError`/`TimeoutExpired`, so the decode error
+  escaped into the agent loop; `GET /namespaces` had no handler at all and would have returned
+  a 500; and three sites — the rollback-point snapshot, `cluster_id`, the context fetcher's pod
+  and event snapshot — sit inside a broad `except Exception`, where the same byte silently meant
+  *the safety feature did not run*.
+
+  `errors="replace"` was applied to the 9 sites that read free-form **content** a human or the
+  model reads, and withheld from the 16 that read an **identifier, a path, or a tool's own
+  structured output**. The line is content-vs-identifier rather than cluster-vs-not: a `U+FFFD`
+  in `kubectl logs` blemishes prose that was already truncated and redacted before anyone saw
+  it, while the same character in a namespace name, a cluster ID or a `git ls-files` path
+  corrupts a key — and every one of those values is ASCII by specification, so strict decoding
+  there can only fire on something genuinely wrong.
+
+  `scripts/check-text-encoding.py` was extended to the shape rather than given a sibling, since
+  its header already named this as the tracked-separately half; it now documents the `errors=`
+  convention as well. Detection matches the pairing of a `text=`/`universal_newlines=` keyword
+  with a call named `run`/`Popen`/`check_output`/`call`/`check_call` — the name alone would flag
+  every `runner.run(...)` in the tree, and requiring a `subprocess.` receiver would miss
+  `from subprocess import run`. It rides in the existing **Syntax warnings** job, so no required
+  check changes name.
+
+  Eleven tests: five red/green cases on the gate, and a new
+  `v4/tests/test_child_output_that_is_not_utf8.py` that spawns a real child emitting a raw
+  `0x80` and asserts both directions — replace survives with a visible marker, strict raises —
+  then AST-pins `errors=` onto the four cluster-output readers by name, so dropping it from
+  `run_kubectl` again cannot pass green.
+
 ### Added
 - **A gate now keeps the two contributor rosters in sync** (#167).
   `.all-contributorsrc` and the **Contributors** table in `README.md` are both hand-maintained,

--- a/scripts/check-contributor-roster.py
+++ b/scripts/check-contributor-roster.py
@@ -64,6 +64,7 @@ def repo_root() -> str:
         ["git", "rev-parse", "--show-toplevel"],  # noqa: S607
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=True,
     ).stdout.strip()
 

--- a/scripts/check-syntax-warnings.py
+++ b/scripts/check-syntax-warnings.py
@@ -62,6 +62,7 @@ def repo_root() -> str:
         capture_output=True,
         check=True,
         text=True,
+        encoding="utf-8",
     ).stdout.strip()
 
 
@@ -82,6 +83,7 @@ def tracked_python_files(root: str | None = None) -> list[str]:
         capture_output=True,
         check=True,
         text=True,
+        encoding="utf-8",
         cwd=root,
     ).stdout
     paths = [p for p in out.split("\0") if p]

--- a/scripts/check-text-encoding.py
+++ b/scripts/check-text-encoding.py
@@ -36,8 +36,27 @@
 # It DOES flag a source file that is not valid UTF-8, rather than skipping it: a
 # file the gate cannot read is a file the gate is not guarding.
 #
-# NOT COVERED, and tracked separately: `subprocess.run(..., text=True)` decodes
-# with the locale encoding too. Same bug class, different call shape.
+# It ALSO flags the subprocess shape (#168): `subprocess.run(..., text=True)`
+# decodes the child's stdout/stderr with the platform default in exactly the same
+# way. The children here are `kubectl`, `helm` and `git`, whose output carries
+# whatever a user named a resource and whatever a container wrote to its logs, so
+# a single non-ASCII byte is enough.
+#
+# The gate requires `encoding=`. It deliberately does NOT require `errors=`: that
+# is a per-call judgement, not a rule a checker can make. The convention this repo
+# settled on in #168 is
+#
+#   errors="replace"  where the bytes are free-form CONTENT a human or the model
+#                     reads — `kubectl logs/describe/get -o yaml`, `helm get`,
+#                     event messages, `git`/`gh` output shown to a caller. Losing
+#                     a whole diagnosis to one bad glyph is the worse failure, and
+#                     U+FFFD is a visible marker where a swallowed exception is not.
+#   strict (default)  where the bytes are an IDENTIFIER, a PATH, or a tool's own
+#                     structured output — namespace and context names, cluster IDs,
+#                     `git ls-files`, `which`, `systemctl is-active`. A replacement
+#                     character there corrupts a key rather than blemishing prose,
+#                     and every one of those values is ASCII by specification, so
+#                     strict can only fire on something genuinely wrong.
 #
 # SCOPE
 #
@@ -59,6 +78,15 @@ import sys
 
 FROZEN_PREFIXES = ("v1/", "v2/", "v3/")
 TEXT_IO_NAMES = ("read_text", "write_text", "open")
+
+# The subprocess entry points that decode the child's pipes when `text=True` (or
+# its older spelling `universal_newlines=True`) is set. Matched on the called name
+# rather than on a `subprocess.` receiver, so `from subprocess import run` is
+# covered too. The pairing is what makes that precise: a `text=`/`universal_newlines=`
+# keyword on a call named `run`/`Popen`/`check_output`/`call`/`check_call` is a
+# subprocess call in practice — those keyword names exist nowhere else in this tree.
+SUBPROCESS_NAMES = ("run", "Popen", "check_output", "call", "check_call")
+_TEXT_MODE_KEYWORDS = ("text", "universal_newlines")
 
 # `<module>.open(...)` calls that are not text-file opens at all. Their signatures
 # have no text `encoding` parameter, so the remediation this gate prints would
@@ -88,6 +116,7 @@ def repo_root() -> str:
         capture_output=True,
         check=True,
         text=True,
+        encoding="utf-8",
     ).stdout.strip()
 
 
@@ -104,6 +133,7 @@ def tracked_python_files(root: str | None = None) -> list[str]:
         capture_output=True,
         check=True,
         text=True,
+        encoding="utf-8",
         cwd=root,
     ).stdout
     paths = [p for p in out.split("\0") if p]
@@ -177,6 +207,25 @@ def _called_name(call: ast.Call) -> str | None:
     return None
 
 
+def _subprocess_decodes_without_encoding(call: ast.Call) -> bool:
+    """True for a subprocess call that decodes its pipes with the platform default.
+
+    A `text=`/`universal_newlines=` value that is not a literal is still flagged: it
+    may be True at runtime, and naming an encoding costs nothing either way. `**kwargs`
+    is skipped for the same reason as the file shapes — the encoding may be forwarded.
+    """
+    text_mode = [k for k in call.keywords if k.arg in _TEXT_MODE_KEYWORDS]
+    if not text_mode:
+        return False  # no text mode: the pipes are bytes and there is nothing to name
+    if any(
+        isinstance(k.value, ast.Constant) and k.value.value is not True for k in text_mode
+    ):
+        return False  # explicitly text=False / universal_newlines=False
+    if any(k.arg == "encoding" for k in call.keywords):
+        return False
+    return not any(k.arg is None for k in call.keywords)
+
+
 def offenders(source: str, path: str) -> list[tuple[str, int, str]]:
     """Every text-mode call in `source` that does not name an encoding."""
     found: list[tuple[str, int, str]] = []
@@ -185,6 +234,10 @@ def offenders(source: str, path: str) -> list[tuple[str, int, str]]:
         if not isinstance(node, ast.Call):
             continue
         name = _called_name(node)
+        if name in SUBPROCESS_NAMES:
+            if _subprocess_decodes_without_encoding(node):
+                found.append((path, node.lineno, f"{name} (text mode)"))
+            continue
         if name not in TEXT_IO_NAMES:
             continue
         if any(keyword.arg == "encoding" for keyword in node.keywords):
@@ -254,18 +307,26 @@ def main(argv: list[str]) -> int:
     if failures:
         print(f"{len(failures)} text-mode call(s) without an explicit encoding:\n")
         for path, lineno, name in failures:
-            if lineno:
+            if lineno and name.endswith(" (text mode)"):
+                print(
+                    f"  {path}:{lineno}  {name.removesuffix(' (text mode)')}() — "
+                    'add encoding="utf-8" (and errors="replace" if it reads cluster output)'
+                )
+            elif lineno:
                 print(f"  {path}:{lineno}  {name}() — add encoding=\"utf-8\"")
             else:
                 print(f"  {path}  {name} — re-save the file as UTF-8")
         print(
             "\nThe platform default is not UTF-8 on Windows or under the C locale, so any"
-            "\nnon-ASCII byte raises UnicodeDecodeError there and nowhere else. See #136/#156."
+            "\nnon-ASCII byte raises UnicodeDecodeError there and nowhere else. See #136/#156/#168."
             '\nBinary mode ("rb"/"wb") is not flagged and needs no encoding.'
         )
         return 1
 
-    print(f"encoding OK — {checked} tracked Python files outside v1-v3 name an encoding on every text-mode call")
+    print(
+        f"encoding OK — {checked} tracked Python files outside v1-v3 name an encoding on "
+        "every text-mode read, write and subprocess call"
+    )
     return 0
 
 

--- a/v4/packages/kubeintellect-server/app/agent/nodes/context_fetcher.py
+++ b/v4/packages/kubeintellect-server/app/agent/nodes/context_fetcher.py
@@ -65,6 +65,7 @@ def _run_kubectl_snapshot(args: list[str]) -> str:
             ["kubectl"] + args,
             capture_output=True,
             text=True,
+            encoding="utf-8", errors="replace",
             timeout=settings.KUBECTL_TIMEOUT_SECONDS,
             env=env,
             shell=False,

--- a/v4/packages/kubeintellect-server/app/api/v1/endpoints/namespaces.py
+++ b/v4/packages/kubeintellect-server/app/api/v1/endpoints/namespaces.py
@@ -26,6 +26,7 @@ def list_namespaces() -> NamespacesResponse:
         args,
         capture_output=True,
         text=True,
+        encoding="utf-8",
         timeout=10,
         env=env,
         shell=False,

--- a/v4/packages/kubeintellect-server/app/cli.py
+++ b/v4/packages/kubeintellect-server/app/cli.py
@@ -436,7 +436,7 @@ def _get_kind_node_ip() -> str:
         result = subprocess.run(
             ["kubectl", "get", "nodes", "-o",
              "jsonpath={.items[0].status.addresses[?(@.type==\"InternalIP\")].address}"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True, text=True, encoding="utf-8", timeout=10,
         )
         return result.stdout.strip()
     except Exception:
@@ -648,6 +648,7 @@ def _service_installed() -> bool:
 def _install_service() -> None:
     kubeintellect_bin = subprocess.run(
         ["which", "kubeintellect"], capture_output=True, text=True,
+        encoding="utf-8",
     ).stdout.strip() or str(Path(sys.executable).parent / "kubeintellect")
 
     _SERVICE_DIR.mkdir(parents=True, exist_ok=True)
@@ -1523,6 +1524,7 @@ def cmd_set(args: argparse.Namespace) -> None:
     svc_active = subprocess.run(
         ["systemctl", "--user", "is-active", _SERVICE_NAME],
         capture_output=True, text=True,
+        encoding="utf-8",
     ).stdout.strip() == "active"
     if svc_active:
         subprocess.run(["systemctl", "--user", "restart", _SERVICE_NAME],
@@ -1610,7 +1612,7 @@ def _get_kube_dns_ip() -> str:
         result = subprocess.run(
             ["kubectl", "get", "svc", "kube-dns", "-n", "kube-system",
              "-o", "jsonpath={.spec.clusterIP}"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True, text=True, encoding="utf-8", timeout=5,
         )
         return result.stdout.strip() if result.returncode == 0 else ""
     except Exception:
@@ -1625,7 +1627,7 @@ def cmd_kind_setup(args: argparse.Namespace) -> None:
     _ensure_tool("kubectl", _install_kubectl)
     _ensure_tool("helm",    _install_helm)
 
-    result = subprocess.run(["kind", "get", "clusters"], capture_output=True, text=True)
+    result = subprocess.run(["kind", "get", "clusters"], capture_output=True, text=True, encoding="utf-8")
     existing = result.stdout.strip().splitlines()
     if cluster_name in existing:
         print(f"  {_ok('✓')}  Kind cluster '{cluster_name}' already exists — skipping creation.")
@@ -1634,6 +1636,7 @@ def cmd_kind_setup(args: argparse.Namespace) -> None:
         result = subprocess.run(
             ["kind", "create", "cluster", "--name", cluster_name],
             check=False, text=True,
+            encoding="utf-8",
         )
         if result.returncode != 0:
             print(_err("  Error: failed to create Kind cluster."), file=sys.stderr)
@@ -1646,7 +1649,7 @@ def cmd_kind_setup(args: argparse.Namespace) -> None:
             "https://raw.githubusercontent.com/kubernetes/ingress-nginx"
             "/main/deploy/static/provider/kind/deploy.yaml"
         )
-        result = subprocess.run(["kubectl", "apply", "-f", ingress_url], check=False, text=True)
+        result = subprocess.run(["kubectl", "apply", "-f", ingress_url], check=False, text=True, encoding="utf-8")
         if result.returncode != 0:
             print(_warn("  Warning: nginx ingress install failed — install it manually later."), file=sys.stderr)
         else:
@@ -1746,7 +1749,7 @@ def _get_kube_context(kube_path: str) -> str:
     try:
         result = subprocess.run(
             ["kubectl", "--kubeconfig", kube_path, "config", "current-context"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True, text=True, encoding="utf-8", timeout=5,
         )
         return result.stdout.strip() if result.returncode == 0 else ""
     except Exception:

--- a/v4/packages/kubeintellect-server/app/cluster_id.py
+++ b/v4/packages/kubeintellect-server/app/cluster_id.py
@@ -36,6 +36,7 @@ def _kubectl(args: list[str], timeout: int = 5) -> str:
             ["kubectl"] + args,
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=timeout,
             env=env,
             shell=False,

--- a/v4/packages/kubeintellect-server/app/tools/aci/gitops.py
+++ b/v4/packages/kubeintellect-server/app/tools/aci/gitops.py
@@ -34,7 +34,7 @@ def _default_runner(argv: list[str]) -> tuple[int, str]:
     import subprocess
     try:
         r = subprocess.run(
-            argv, capture_output=True, text=True, timeout=_DEFAULT_TIMEOUT_S
+            argv, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=_DEFAULT_TIMEOUT_S
         )
     except subprocess.TimeoutExpired:
         # Non-zero + a readable reason: push failure surfaces to the caller, and a `gh` timeout

--- a/v4/packages/kubeintellect-server/app/tools/helm_tool.py
+++ b/v4/packages/kubeintellect-server/app/tools/helm_tool.py
@@ -121,6 +121,7 @@ def run_helm(command: str) -> str:
             tokens,
             capture_output=True,
             text=True,
+            encoding="utf-8", errors="replace",
             timeout=30,
         )
     except FileNotFoundError:

--- a/v4/packages/kubeintellect-server/app/tools/kubectl_tool.py
+++ b/v4/packages/kubeintellect-server/app/tools/kubectl_tool.py
@@ -330,7 +330,7 @@ def _capture_rollback_point(verb: str, args: list, stdin: str | None, config, en
         for target in targets[:5]:
             try:
                 pre = subprocess.run(
-                    target, capture_output=True, text=True, timeout=5, env=env, shell=False
+                    target, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5, env=env, shell=False
                 )
                 if pre.returncode == 0 and pre.stdout:
                     states.append(redact_secrets(pre.stdout, max_chars=4000))
@@ -531,6 +531,7 @@ def run_kubectl(
             input=stdin,
             capture_output=True,
             text=True,
+            encoding="utf-8", errors="replace",
             timeout=timeout,
             env=env,
             shell=False,

--- a/v4/scripts/aci_sandbox_probe.py
+++ b/v4/scripts/aci_sandbox_probe.py
@@ -31,7 +31,7 @@ def _kubectl(argstr: str) -> str:
     args = shlex.split(argstr)
     if args and args[0] == "kubectl":
         args = args[1:]
-    r = subprocess.run(["kubectl", *args], capture_output=True, text=True, env=env)
+    r = subprocess.run(["kubectl", *args], capture_output=True, text=True, encoding="utf-8", errors="replace", env=env)
     return (r.stdout + r.stderr).strip()
 
 

--- a/v4/scripts/aci_token_ab.py
+++ b/v4/scripts/aci_token_ab.py
@@ -32,7 +32,7 @@ def toks(s: str) -> int:
 def _raw(cmd: str) -> str:
     """TRUE unbounded kubectl output — what a naive 'dump stdout' tool costs."""
     env = {**os.environ, "KUBECONFIG": os.path.expanduser(os.environ["KUBECONFIG_PATH"])}
-    p = subprocess.run(shlex.split(cmd), capture_output=True, text=True, env=env, timeout=30)
+    p = subprocess.run(shlex.split(cmd), capture_output=True, text=True, encoding="utf-8", errors="replace", env=env, timeout=30)
     return p.stdout or p.stderr or "(no output)"
 
 

--- a/v4/scripts/check_doc_claims.py
+++ b/v4/scripts/check_doc_claims.py
@@ -110,6 +110,7 @@ def _collect_count(rootdir: Path) -> int | None:
             cwd=rootdir,
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=300,
         )
     except (OSError, subprocess.TimeoutExpired):

--- a/v4/scripts/fix_pr_probe.py
+++ b/v4/scripts/fix_pr_probe.py
@@ -33,7 +33,7 @@ def check(name: str, cond: bool, detail: str = "") -> None:
 
 
 def _git(repo: Path, *args: str) -> str:
-    r = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
+    r = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True, encoding="utf-8", errors="replace")
     return (r.stdout + r.stderr).strip()
 
 

--- a/v4/scripts/opsmembench_live_probe.py
+++ b/v4/scripts/opsmembench_live_probe.py
@@ -45,7 +45,7 @@ def check(name: str, cond: bool, detail: str = "") -> None:
 
 def _kubectl(cmd: str) -> str:
     env = {**os.environ, "KUBECONFIG": os.path.expanduser(os.environ["KUBECONFIG_PATH"])}
-    return subprocess.run(shlex.split(cmd), capture_output=True, text=True, env=env, timeout=30).stdout
+    return subprocess.run(shlex.split(cmd), capture_output=True, text=True, encoding="utf-8", errors="replace", env=env, timeout=30).stdout
 
 
 def capture_snapshot() -> dict[str, str]:

--- a/v4/tests/test_child_output_that_is_not_utf8.py
+++ b/v4/tests/test_child_output_that_is_not_utf8.py
@@ -1,0 +1,96 @@
+"""#168 — a non-UTF-8 byte from kubectl/helm/git must not take the caller down.
+
+Two halves, and the second is what keeps the first honest:
+
+  * the runtime contract — a child that writes an undecodable byte is survivable
+    with `errors="replace"` and fatal without it, run for real against a real
+    child process rather than asserted from the signature;
+  * the policy — the call sites that read free-form CLUSTER output actually carry
+    `errors="replace"`. `scripts/check-text-encoding.py` gates `encoding=`, which
+    is a rule a checker can state. Which sites deserve `errors=` is a judgement,
+    so it is pinned here by name instead: dropping it from `run_kubectl` would
+    otherwise be an invisible, green regression back to #168.
+
+The byte is 0x80 — a UTF-8 continuation byte with no lead byte, invalid in any
+position. `kubectl logs` returns whatever the container wrote to stdout, so this
+is a container writing latin-1, not a hypothetical.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SERVER = Path(__file__).resolve().parent.parent / "packages" / "kubeintellect-server"
+
+# A child that writes one raw undecodable byte between two readable lines.
+_EMIT_BAD_BYTE = (
+    "import sys; "
+    "sys.stdout.buffer.write(b'NAME  READY\\nweb-\\x80-0  1/1\\n'); "
+    "sys.stdout.buffer.flush()"
+)
+
+
+def test_replace_survives_an_undecodable_byte():
+    proc = subprocess.run(
+        [sys.executable, "-c", _EMIT_BAD_BYTE],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+    )
+    assert proc.returncode == 0
+    # Nothing else is lost: both lines survive and only the bad byte is marked.
+    assert "NAME  READY" in proc.stdout
+    assert "1/1" in proc.stdout
+    assert "�" in proc.stdout, "the replacement must be visible, not silent"
+
+
+def test_strict_would_have_failed_the_whole_read():
+    """Not vacuous: without errors="replace" the same child kills the caller."""
+    with pytest.raises(UnicodeDecodeError):
+        subprocess.run(
+            [sys.executable, "-c", _EMIT_BAD_BYTE],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=30,
+        )
+
+
+@pytest.mark.parametrize(
+    ("relpath", "func", "why"),
+    [
+        ("app/tools/kubectl_tool.py", "run_kubectl", "kubectl logs/describe/get -o yaml"),
+        ("app/tools/kubectl_tool.py", "_capture_rollback_point", "pre-state YAML snapshot"),
+        ("app/tools/helm_tool.py", "run_helm", "helm get values/manifest"),
+        ("app/agent/nodes/context_fetcher.py", "_run_kubectl_snapshot", "pod list + events"),
+    ],
+)
+def test_cluster_output_readers_keep_errors_replace(relpath: str, func: str, why: str):
+    path = _SERVER / relpath
+    tree = ast.parse(path.read_text(encoding="utf-8"), str(path))
+    calls = [
+        node
+        for parent in ast.walk(tree)
+        if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)) and parent.name == func
+        for node in ast.walk(parent)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in ("run", "Popen", "check_output")
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "subprocess"
+    ]
+    assert calls, f"{relpath}:{func} no longer runs a subprocess — re-pin this test"
+    for call in calls:
+        kwargs = {k.arg for k in call.keywords if k.arg}
+        assert "encoding" in kwargs, f"{relpath}:{call.lineno} ({why}) lost encoding="
+        assert "errors" in kwargs, (
+            f'{relpath}:{call.lineno} ({why}) lost errors="replace" — one bad byte '
+            "would take the whole read down again (#168)"
+        )

--- a/v4/tests/test_encoding_gate.py
+++ b/v4/tests/test_encoding_gate.py
@@ -222,3 +222,88 @@ def test_path_constructed_inline_is_still_in_scope(tmp_path: Path):
     checked, failures = checker.check_paths([str(inline)])
     assert checked == 1
     assert [lineno for _path, lineno, _name in failures] == [3, 4]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #168 — the subprocess half of the same bug class.
+# `subprocess.run(..., text=True)` decodes the child's pipes with the platform
+# default just as `read_text()` decodes a file with it.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_bare_subprocess_text_mode_is_caught(tmp_path: Path):
+    checker = _load_checker()
+    src = tmp_path / "child.py"
+    src.write_text(
+        "import subprocess\n"
+        "subprocess.run(['kubectl', 'logs', 'p'], capture_output=True, text=True)\n"
+        "subprocess.check_output(['git', 'log'], text=True)\n"
+        "subprocess.Popen(['helm', 'list'], universal_newlines=True)\n",
+        encoding="utf-8",
+    )
+    checked, failures = checker.check_paths([str(src)])
+    assert checked == 1
+    assert [f[1] for f in failures] == [2, 3, 4], failures
+    # The remediation must name the call that was flagged, not a file-IO fix.
+    assert all("text mode" in f[2] for f in failures), failures
+
+
+def test_subprocess_without_text_mode_is_not_flagged(tmp_path: Path):
+    """Byte pipes decode nothing, so there is no encoding to name."""
+    checker = _load_checker()
+    src = tmp_path / "bytes.py"
+    src.write_text(
+        "import subprocess\n"
+        "subprocess.run(['kubectl', 'get', 'po'], capture_output=True)\n"
+        "subprocess.run(['kubectl', 'get', 'po'], capture_output=True, text=False)\n"
+        "subprocess.run(['kubectl', 'get', 'po'], universal_newlines=False)\n",
+        encoding="utf-8",
+    )
+    checked, failures = checker.check_paths([str(src)])
+    assert checked == 1
+    assert failures == []
+
+
+def test_subprocess_with_encoding_or_forwarded_kwargs_passes(tmp_path: Path):
+    checker = _load_checker()
+    src = tmp_path / "ok.py"
+    src.write_text(
+        "import subprocess\n"
+        "subprocess.run(['git', 'status'], text=True, encoding='utf-8')\n"
+        "subprocess.run(['kubectl', 'logs', 'p'], text=True, encoding='utf-8',"
+        " errors='replace')\n"
+        "def wrap(**kw):\n"
+        "    return subprocess.run(['git', 'status'], text=True, **kw)\n",
+        encoding="utf-8",
+    )
+    checked, failures = checker.check_paths([str(src)])
+    assert checked == 1
+    assert failures == []
+
+
+def test_dynamic_text_mode_is_flagged(tmp_path: Path):
+    """`text=flag` may be True at runtime; naming an encoding costs nothing either way."""
+    checker = _load_checker()
+    src = tmp_path / "dyn.py"
+    src.write_text(
+        "import subprocess\n"
+        "def go(flag):\n"
+        "    return subprocess.run(['git', 'log'], capture_output=True, text=flag)\n",
+        encoding="utf-8",
+    )
+    _, failures = checker.check_paths([str(src)])
+    assert [f[1] for f in failures] == [3], failures
+
+
+def test_unrelated_run_without_a_text_keyword_is_not_flagged(tmp_path: Path):
+    """The name alone must not be enough — `.run()` is far too common a method name."""
+    checker = _load_checker()
+    src = tmp_path / "unrelated.py"
+    src.write_text(
+        "def go(runner, task):\n"
+        "    runner.run(task, verbose=True)\n"
+        "    return task.call(retries=3)\n",
+        encoding="utf-8",
+    )
+    _, failures = checker.check_paths([str(src)])
+    assert failures == []


### PR DESCRIPTION
Closes #168.

`subprocess.run(..., text=True)` decodes the child's pipes with the platform default,
exactly as `read_text()` decodes a file with it. #161 closed the file half of #136/#156
and left this one standing. The children here are `kubectl`, `helm` and `git`, so the
bytes are whatever a user named a resource and whatever a container wrote to its logs —
on Windows (CP1252/CP936) or under the POSIX `C` locale, one non-ASCII byte is enough.

### Scope — 25, not 23

The issue counted 23. On `main` today it is **25 call sites in 12 files**: #167/#171 added
one (`check-contributor-roster.py`) and #161 grew two of its own. The issue's own grep now
prints 26, one of which is the `NOT COVERED` comment in the gate header.

### The `errors=` decision, which #168 asked to be argued rather than assumed

The inclination in the issue was `errors="replace"` on cluster output and strict elsewhere.
That is very close, but *cluster-vs-not* is not the line that holds. The line is
**content vs identifier**:

> `errors="replace"` where the decoded bytes are free-form **content** a human or the model
> will read. Strict where they are an **identifier**, a **path**, or a tool's own
> **structured output**.

Three things make the replace side safe here, and they are specific to these call sites:

1. **The output is already lossy.** Every content site truncates (`[:_SNAPSHOT_MAX_CHARS]`,
   `max_chars=4000`) and redacts (`redact_secrets`) before anything reads it. `errors="replace"`
   is one more lossy transform of the same kind — it does not cross a new line.
2. **U+FFFD is not silent, and the status quo is.** The objection to replacement is that
   silently substituting bytes is how a wrong answer looks right. But `�` is visible and
   greppable. What is actually silent today is *strict*: three of the content sites wrap the
   call in a broad `except Exception` — `_capture_rollback_point` (`continue`),
   `cluster_id._kubectl` (`return ""`), `context_fetcher._run_kubectl_snapshot`
   (`return "(unavailable: …)"`). There, one unreadable glyph currently means **the rollback
   point was never armed**, with no marker at all.
3. **Two failures are severe.** `run_kubectl` catches only `FileNotFoundError` and
   `TimeoutExpired`, so a `UnicodeDecodeError` escapes into the agent loop.
   `api/v1/endpoints/namespaces.py` has no `try` at all — it is a 500 on a public endpoint.

And what makes the strict side *correct* rather than merely conservative: every identifier read
here is **ASCII by specification**. Namespace and context names are RFC-1123 constrained;
`which` returns a path; `systemctl is-active` returns a literal. A `�` in any of those corrupts
a **key** — it would fork a cluster identity, or name a namespace that does not exist — where
strict decoding can only fire on something genuinely wrong. `git ls-files` is the sharpest case:
replacing a byte there yields a path that cannot be opened, which is a worse and far more
confusing failure than the decode error.

One site sits on the boundary and went **strict deliberately**: `v4/scripts/check_doc_claims.py`
regexes a count out of pytest output. It reads free-form text, but it is a *gate*, and a gate
that dies loudly on a stray byte is behaving correctly.

Two sites (`cli.py:1636`, `cli.py:1649`) pass `text=True` with no pipes, where it decodes
nothing at all today. They were annotated rather than deleted: the moment someone adds
`capture_output=True`, they become locale-dependent silently.

**Split: 9 `errors="replace"` / 16 strict.**

| `errors="replace"` — content | strict — identifier / path / tool output |
|---|---|
| `kubectl_tool` rollback `get -o yaml` | `namespaces.py`, `cluster_id.py` |
| `kubectl_tool.run_kubectl` (logs/describe/get) | `cli.py` ×8 |
| `helm_tool.run_helm` | `check_doc_claims.py` |
| `context_fetcher` pods + events | `check-syntax-warnings.py` ×2 |
| `aci/gitops` git/gh reason string | `check-contributor-roster.py` |
| the four `v4/scripts/*_probe`-style scripts | `check-text-encoding.py` ×2 |

### The gate

`scripts/check-text-encoding.py` was **extended in place** rather than given a sibling — its
header already named this shape as "NOT COVERED, tracked separately", so that header is now the
documentation of the `errors=` convention too.

Detection matches on the **pairing** of a `text=`/`universal_newlines=` keyword with a call named
`run`/`Popen`/`check_output`/`call`/`check_call`. Matching the name alone would flag every
`runner.run(...)` in the tree; requiring a `subprocess.` receiver would miss
`from subprocess import run`. A non-literal `text=flag` is flagged (it may be `True` at runtime);
an explicit `text=False` is not.

It rides in the existing **Syntax warnings** job. Branch protection matches required checks by
name, so a new job would be one `main` does not require — the same reasoning as #167.

### Evidence

| Check | Result |
|---|---|
| AST sweep of the whole tracked tree | **0** subprocess text-mode calls without `encoding=`, 310 files |
| extended gate, patched tree | `exit 0` |
| extended gate, 5 **pre-fix** files restored from `main` | `exit 1`, **14** offenders — the red case |
| `check-syntax-warnings` / `check-contributor-roster` / `check-file-modes` | `exit 0` |
| `ruff check`, all 19 changed files | `All checks passed!` |
| `mypy` (app + ki-protocol + kube_q) | **Success: no issues found in 172 source files** |
| `pytest tests/` **before** | 13 failed, 1055 passed |
| `pytest tests/` **after** | 13 failed, **1066** passed — same 13, **zero new** |

Those 13 are pre-existing on pristine `main` in that local environment (GPU collector, prometheus
trends, budget gate, version axes). CI is green on `main`, so they are environmental; they were
measured only to establish the baseline and are **not** diagnosed here.

### Done-when, against #168

- [x] no `text=True` without an `encoding=` outside `v1/`–`v3/`
- [x] the `errors=` decision recorded with its reasoning (above)
- [x] the gate catches the shape, with red tests
- [x] a regression test that a non-UTF-8 byte in child output does not blow up the caller —
      `v4/tests/test_child_output_that_is_not_utf8.py` spawns a real child emitting a raw `0x80`
      and asserts **both** directions (replace survives with a visible marker; strict raises),
      then AST-pins `errors=` onto the four cluster-output readers by name, so dropping it from
      `run_kubectl` again cannot pass green

### Note for the merger — this PR is itself an instance of #154

It moves the server-suite count `1068 → 1079` in `AGENTS.md`. If anything else that adds tests
merges first, this goes red on `main` rather than here, because branch protection has
`required_status_checks.strict = false`. Re-run before merging, or merge this one first.
