### PR TITLE
fix(agent): isolate failures in parallel tool batches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,6 +257,12 @@ A change that violates any of these will be rejected regardless of test results.
    behavioural test while silently receiving `None`. A behavioural test cannot catch that;
    only asserting the annotation can.
 
+7. **One read-tool failure must not abort a parallel batch.** The default coordinator and
+   specialist ReAct loops must pass tools through
+   `app.agent.tool_execution.fault_isolated_tool_node`. Ordinary invocation errors become
+   per-call error `ToolMessage`s that include the failed command and reason, while
+   `GraphInterrupt` must still escape unchanged for HITL mutation approval.
+
 ## Testing expectations
 
 - Every behavioral change needs a test that **fails before your change and passes after.**

--- a/v4/packages/kubeintellect-server/app/agent/nodes/coordinator.py
+++ b/v4/packages/kubeintellect-server/app/agent/nodes/coordinator.py
@@ -16,6 +16,7 @@ from langchain_core.runnables import RunnableConfig
 from langgraph.errors import GraphInterrupt, GraphRecursionError
 
 from app.agent.state import AgentState, PlanStep
+from app.agent.tool_execution import fault_isolated_tool_node
 from app.core.config import settings
 from app.core.llm import get_coordinator_llm
 from app.streaming.emitter import PlanEvent, StatusEvent, emit
@@ -853,7 +854,7 @@ async def _direct_answer(state: AgentState, config: Optional[RunnableConfig] = N
         system_parts.append(_PROACTIVE_FIX_BLOCK)
 
     llm = get_coordinator_llm()
-    agent = create_react_agent(llm, tools=ALL_TOOLS)
+    agent = create_react_agent(llm, tools=fault_isolated_tool_node(ALL_TOOLS))
 
     history, history_summary = _trim_session_messages(list(state["messages"]))
     if history_summary:

--- a/v4/packages/kubeintellect-server/app/agent/nodes/subagent.py
+++ b/v4/packages/kubeintellect-server/app/agent/nodes/subagent.py
@@ -7,6 +7,7 @@ from langchain_core.messages import SystemMessage
 from langgraph.prebuilt import create_react_agent
 
 from app.agent.state import AgentFinding, SubagentInput
+from app.agent.tool_execution import fault_isolated_tool_node
 from app.core.llm import get_subagent_llm
 from app.tools.registry import ALL_TOOLS
 from app.utils.logger import get_logger
@@ -91,7 +92,7 @@ async def run_subagent(payload: SubagentInput) -> AgentFinding:
     system_prompt = "\n".join(system_parts)
 
     llm = get_subagent_llm()
-    agent = create_react_agent(llm, tools=ALL_TOOLS)
+    agent = create_react_agent(llm, tools=fault_isolated_tool_node(ALL_TOOLS))
 
     input_messages = [SystemMessage(content=system_prompt)] + list(messages)
 

--- a/v4/packages/kubeintellect-server/app/agent/tool_execution.py
+++ b/v4/packages/kubeintellect-server/app/agent/tool_execution.py
@@ -1,0 +1,49 @@
+"""Shared fault-isolation boundary for ReAct tool batches."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Sequence
+
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import BaseTool
+from langgraph.errors import GraphInterrupt
+from langgraph.prebuilt import ToolNode
+from langgraph.prebuilt.tool_node import ToolCallRequest
+from langgraph.types import Command
+
+from app.utils.logger import get_logger
+from app.utils.redact import redact_secrets
+
+logger = get_logger(__name__)
+
+
+async def _isolate_tool_failure(
+    request: ToolCallRequest,
+    execute: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
+) -> ToolMessage | Command:
+    """Convert one ordinary failure to a result without weakening HITL."""
+    try:
+        return await execute(request)
+    except GraphInterrupt:
+        raise
+    except Exception as exc:
+        call = request.tool_call
+        name = call.get("name", "")
+        command = (call.get("args") or {}).get("command")
+        safe_command = redact_secrets(command, max_chars=500) if isinstance(command, str) else ""
+        invocation = f" command={safe_command!r}" if safe_command else ""
+        reason = redact_secrets(str(exc), max_chars=500)
+        logger.warning(
+            f"tool call failed independently: {name}{invocation}: {reason}",
+            extra={"tool_name": name, "tool_call_id": call.get("id", "")},
+        )
+        return ToolMessage(
+            tool_call_id=call.get("id", ""),
+            name=name,
+            status="error",
+            content=f"Tool error: {name}{invocation}: {reason}",
+        )
+
+
+def fault_isolated_tool_node(tools: Sequence[BaseTool]) -> ToolNode:
+    """Build a parallel ToolNode where each ordinary call fails independently."""
+    return ToolNode(tools, awrap_tool_call=_isolate_tool_failure)

--- a/v4/tests/test_parallel_tool_failure_isolation.py
+++ b/v4/tests/test_parallel_tool_failure_isolation.py
@@ -1,0 +1,111 @@
+"""One malformed read must not discard successful calls from the same batch."""
+from __future__ import annotations
+
+from langchain_core.messages import AIMessage, ToolMessage
+from langchain_core.tools import tool
+from langgraph.errors import GraphInterrupt
+from langgraph.graph import END, START, MessagesState, StateGraph
+
+from app.agent.tool_execution import fault_isolated_tool_node
+
+
+def _compiled_tool_node(tools):
+    graph = StateGraph(MessagesState)
+    graph.add_node("tools", fault_isolated_tool_node(tools))
+    graph.add_edge(START, "tools")
+    graph.add_edge("tools", END)
+    return graph.compile()
+
+
+@tool
+async def run_kubectl(command: str) -> str:
+    """Return deterministic output for a read-only kubectl command."""
+    if "<" in command or ">" in command:
+        raise ValueError("Command contains disallowed shell characters")
+    return f"result for {command}"
+
+
+@tool
+async def mutate_cluster(command: str) -> str:
+    """Model the interrupt raised by a mutation awaiting human approval."""
+    raise GraphInterrupt()
+
+
+async def test_one_invalid_call_does_not_abort_parallel_read_results():
+    graph = _compiled_tool_node([run_kubectl])
+    commands = [
+        "kubectl get nodes -o wide",
+        "kubectl describe pod payments -n shop",
+        "kubectl get events -n shop",
+        "kubectl logs checkout -n shop",
+        "kubectl describe pod worker -n shop",
+        "kubectl get pods -n shop",
+        "kubectl describe node <node-name>",
+    ]
+    batch = AIMessage(
+        content="",
+        tool_calls=[
+            {"name": "run_kubectl", "args": {"command": command}, "id": f"call-{index}"}
+            for index, command in enumerate(commands)
+        ],
+    )
+
+    result = await graph.ainvoke({"messages": [batch]})
+    messages = [message for message in result["messages"] if isinstance(message, ToolMessage)]
+
+    assert len(messages) == 7
+    assert sum(message.status == "success" for message in messages) == 6
+    failures = [message for message in messages if message.status == "error"]
+    assert len(failures) == 1
+    assert isinstance(failures[0], ToolMessage)
+    assert "kubectl describe node <node-name>" in failures[0].content
+    assert "Command contains disallowed shell characters" in failures[0].content
+
+
+async def test_hitl_graph_interrupt_is_not_converted_to_a_tool_error():
+    graph = _compiled_tool_node([mutate_cluster])
+    batch = AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "name": "mutate_cluster",
+                "args": {"command": "kubectl delete pod checkout"},
+                "id": "mutation-1",
+            }
+        ],
+    )
+
+    result = await graph.ainvoke({"messages": [batch]})
+
+    assert not any(isinstance(message, ToolMessage) for message in result["messages"])
+
+
+async def test_failed_command_and_reason_are_redacted_before_returning():
+    @tool
+    async def failing_tool(command: str) -> str:
+        """Fail with the submitted command in the exception text."""
+        raise ValueError(f"rejected {command}")
+
+    graph = _compiled_tool_node([failing_tool])
+    secret = "sk-test-abcdefghijklmnopqrstuvwxyz123456"
+    batch = AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "name": "failing_tool",
+                "args": {"command": f"kubectl get pods --token={secret}"},
+                "id": "failure-1",
+            }
+        ],
+    )
+
+    result = await graph.ainvoke({"messages": [batch]})
+    failures = [
+        message
+        for message in result["messages"]
+        if isinstance(message, ToolMessage) and message.status == "error"
+    ]
+
+    assert len(failures) == 1
+    assert secret not in failures[0].content
+    assert "<redacted>" in failures[0].content


### PR DESCRIPTION
## What & why

A malformed tool call currently raises out of LangGraph's parallel `ToolNode`, discarding successful investigation results from the same batch. This adds a shared fault-isolation boundary for coordinator and specialist ReAct loops: ordinary failures become redacted per-call error results, while `GraphInterrupt` still escapes for HITL approval.

Closes #174

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📖 Docs
- [ ] 🧹 Refactor / chore
- [ ] ⚡ Performance
- [x] 🧪 Tests

## Scope

- Version directory touched: `v4/`
- [x] This change is scoped to a version whose contributions are open (`v4/`, or docs/typos in older versions).

## Checklist

- [x] New behavior has both a **happy-path** and an **error-path** test
- [x] **Every mutating/write operation keeps its dry-run + diff + human-approval (HITL) gate** (safety invariant)
- [x] Secret values are never logged or returned (key names only)
- [ ] `uv run pytest` passes locally
- [x] `uv run ruff check .` passes locally
- [x] `uv run mypy src` passes locally
- [x] Docs updated if behavior/CLI/flags changed

## Notes for reviewers

- The regression builds a real compiled LangGraph with seven parallel calls and proves six valid results survive one malformed call.
- A separate test proves `GraphInterrupt` is not converted into a tool error; another proves command and exception credentials are redacted.
- Focused agent tests: 71 passed.
- Full server suite: 5,455 passed, 23 skipped, 29 host/pre-existing failures. The failures require a missing monospace font, rely on GNU `chmod --` behavior unavailable on macOS, or flag floating GitHub Action references already present on `main`; none touch the changed paths.
- Exact workspace Ruff, mypy, doc-claims, file-mode, syntax, encoding, and contributor-roster gates passed.

Substantial AI assistance was used to inspect the LangGraph execution boundary, implement the change, and develop the tests. I reviewed the resulting diff and ran the validation listed above.
