### PR TITLE
fix(ci): pin docs.yml's five actions to commit SHAs — unblocks a red `main`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,9 +40,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.12"
           cache: pip
@@ -55,12 +55,12 @@ jobs:
       - name: Build the published site
         run: ./scripts/build-docs.sh "$GITHUB_WORKSPACE/site"
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5.0.0
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
         with:
           path: site
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5


### PR DESCRIPTION
`Tests (server)` is a **required check** and has been failing on `main` itself, so every open PR inherits a red check and cannot merge.

```
unpinned action reference(s): docs.yml:43 actions/checkout@v5, docs.yml:45 actions/setup-python@v6,
docs.yml:58 actions/configure-pages@v5, docs.yml:60 actions/upload-pages-artifact@v3,
docs.yml:66 actions/deploy-pages@v4
```

Reproduced on `origin/main` untouched. `docs.yml` arrived with floating tags; the gate exists because a mutable tag is a supply-chain hole in a pipeline that signs and publishes artifacts.

Pinned to the newest release **within each currently-referenced major** — this workflow deploys the live docs site, and `upload-pages-artifact` v3→v5 / `deploy-pages` v4→v5 are major bumps that do not belong in a change whose only job is turning CI green. Those upgrades are already open as their own Dependabot PRs.

Verified: `tests/test_what_you_installed_can_be_traced_to_its_build.py` — **33 passed** (was 1 failed).