### PR TITLE
playbook: add DnsResolutionFailure (#134 by @uuzzrm, closes #96)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ uv run ruff check packages/kubeintellect-server/app/ packages/ki-protocol/ packa
 # 2. Types — the workspace is at ZERO errors; keep it there.
 uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube-q/kube_q
 
-# 3. Server suite (5510 tests)
+# 3. Server suite (5515 tests)
 uv run python -m pytest tests/ -q
 
 # 4. kq CLI suite (749 tests)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,7 @@ The `v4/` platform is the current line and the only one you should deploy.
 - Conversational diagnosis correlating **kubectl + Prometheus + Loki**.
 - **Human-in-the-loop approval gate** with RBAC (superadmin / admin / operator / readonly) on
   every mutating action, enforced server-side at the mutating chokepoint.
-- **23 declarative failure playbooks** (`detect → investigate → remediate`), 20 of which compile
+- **24 declarative failure playbooks** (`detect → investigate → remediate`), 20 of which compile
   to zero-token detectors.
 - **Zero-token detection** — a detector engine over a kubectl `--watch` sensorium fires
   findings without invoking the LLM.
@@ -51,7 +51,7 @@ These are concrete, scoped, and mostly open to contribution.
 | **Composable detectors** — AND / NOT / temporal windows | Open | [#21](https://github.com/MSKazemi/kubeintellect/issues/21) ✅ |
 | **PromQL execution in playbook `detect` blocks** | Open | [#20](https://github.com/MSKazemi/kubeintellect/issues/20) ✅ |
 | **Temporal KG ingesting nodes / events / PVCs** | Open | [#19](https://github.com/MSKazemi/kubeintellect/issues/19) ✅ |
-| Grow the **playbook library** beyond 23 | Ongoing — a playbook is one YAML file; 18 → 23 in Aug 2026 via [#108](https://github.com/MSKazemi/kubeintellect/pull/108), [#112](https://github.com/MSKazemi/kubeintellect/pull/112), [#114](https://github.com/MSKazemi/kubeintellect/pull/114), [#127](https://github.com/MSKazemi/kubeintellect/pull/127) and [#128](https://github.com/MSKazemi/kubeintellect/pull/128) | [#13](https://github.com/MSKazemi/kubeintellect/issues/13) ✅ |
+| Grow the **playbook library** beyond 24 | Ongoing — a playbook is one YAML file; 18 → 23 in Aug 2026 via [#108](https://github.com/MSKazemi/kubeintellect/pull/108), [#112](https://github.com/MSKazemi/kubeintellect/pull/112), [#114](https://github.com/MSKazemi/kubeintellect/pull/114), [#127](https://github.com/MSKazemi/kubeintellect/pull/127) and [#128](https://github.com/MSKazemi/kubeintellect/pull/128) | [#13](https://github.com/MSKazemi/kubeintellect/issues/13) ✅ |
 
 ## Housekeeping — known debt, stated plainly
 

--- a/v4/docs/agent-behaviors.md
+++ b/v4/docs/agent-behaviors.md
@@ -236,7 +236,7 @@ detects a matching pattern in the snapshot, the coordinator's system prompt
 includes the playbook(s) inline — guiding it to follow proven steps before
 improvising.
 
-**Playbooks shipped (23):**
+**Playbooks shipped (24):**
 
 *Pod / container lifecycle*
 
@@ -269,6 +269,7 @@ improvising.
 - `DeploymentRolloutStuck` (`ProgressDeadlineExceeded` — new ReplicaSet never becomes Available)
 - `WebhookAdmissionRejected`
 - `HPANotScaling` (metrics-server missing/unreachable, or container missing `resources.requests.cpu`)
+- `DnsResolutionFailure` (in-cluster resolution failing — CoreDNS down, or broken `dnsPolicy`/`dnsConfig`/policy on port 53)
 
 **Schema** (drop a YAML file into `app/agent/playbooks/`):
 
@@ -668,11 +669,12 @@ triggers:
     threshold on the first scrape. That depends on runtime values, so it belongs to a
     shadow period and a human, not to a validator.
 
-Of the 23 shipped playbooks, **20 compile to detectors**; 3 are LLM-only
+Of the 24 shipped playbooks, **20 compile to detectors**; 4 are LLM-only
 (`CommandHardcodedFailure` — disambiguated from CrashLoopBackOff only by
-reading the pod spec — `ServiceUnreachable`, and `NetworkPolicyBlocking`,
+reading the pod spec — `ServiceUnreachable`, `NetworkPolicyBlocking`,
 where the packet is discarded in the CNI datapath so no machine signal
-reaches the API server at all).
+reaches the API server at all, and `DnsResolutionFailure`, which surfaces
+in application logs the watch sensorium never sees).
 
 ### Sensorium + detector engine (zero-token detection)
 

--- a/v4/docs/architecture.md
+++ b/v4/docs/architecture.md
@@ -487,7 +487,7 @@ packages/
 │   │   ├── coordinator.py        — LLM decision + synthesis, tool trimmer, reflexion writes
 │   │   ├── memory_loader.py      — load pinned cluster context + failure-pattern hints
 │   │   └── subagent.py           — 4 specialist subagent runners
-│   ├── playbooks/                — YAML playbook library + loader (23 playbooks)
+│   ├── playbooks/                — YAML playbook library + loader (24 playbooks)
 │   ├── state.py                  — AgentState, SubagentInput, AgentFinding, RCAResult
 │   ├── workflow.py               — LangGraph graph, targeted_investigator, route_coordinator
 │   └── hitl.py                   — HITL approval/denial detection

--- a/v4/docs/capabilities.md
+++ b/v4/docs/capabilities.md
@@ -36,7 +36,7 @@ Metrics and logs are optional — without them, KubeIntellect still answers ever
 
 V4 also works *between* your questions:
 
-- **Zero-token known-failure detection** — the playbook library covers the 23 most common failures, and compiled detectors recognize 20 of them straight off the live cluster stream without spending a single LLM token. → [Agent Behaviors → V4 additions](agent-behaviors.md#v4-additions)
+- **Zero-token known-failure detection** — the playbook library covers the 24 most common failures, and compiled detectors recognize 20 of them straight off the live cluster stream without spending a single LLM token. → [Agent Behaviors → V4 additions](agent-behaviors.md#v4-additions)
 - **Self-opened investigations** — a firing detector opens its own investigation and publishes the report; how far it may go is set per namespace (A0–A3). → [Autonomous Operations](autonomy.md)
 - **Morning digest** — `kq digest` summarizes findings, autonomous investigations, and rollback points from the last N hours. → [Autonomous Operations → digest](autonomy.md#the-morning-digest)
 - **Tamper-evident audit replay** — every session is hash-chained in an append-only log; `kq replay <session-id>` reproduces it and verifies integrity. → [Flight Recorder & Replay](flight-recorder.md)
@@ -48,7 +48,7 @@ V4 also works *between* your questions:
 
 ## Failure patterns it recognizes
 
-KubeIntellect ships **23 built-in playbooks** — deterministic investigation
+KubeIntellect ships **24 built-in playbooks** — deterministic investigation
 recipes for the most common Kubernetes failures. When the cluster snapshot
 matches a pattern, the matching playbook guides the investigation automatically.
 You don't invoke these by name; they fire on their own.

--- a/v4/docs/examples.md
+++ b/v4/docs/examples.md
@@ -495,7 +495,7 @@ See [CLI Reference → `kq export`](cli-reference.md#kq-export-session-id).
 
 ## 14 · Teach it a new failure — `kq detector`
 
-Your cluster fails in a way the 23 shipped playbooks do not cover, and you want it recognised without writing Python.
+Your cluster fails in a way the 24 shipped playbooks do not cover, and you want it recognised without writing Python.
 
 **You run:**
 

--- a/v4/docs/faq.md
+++ b/v4/docs/faq.md
@@ -144,7 +144,7 @@ Plain ChatGPT can't see your cluster; KubeIntellect grounds every answer in live
 `kubectl` / Helm / Prometheus / Loki data. Beyond running commands, it adds
 capabilities those command-shaped tools don't combine: **parallel specialist
 subagents** (pod / metrics / logs / events) that fan out for a real root-cause
-analysis, **23 deterministic playbooks** that guide known-failure investigations,
+analysis, **24 deterministic playbooks** that guide known-failure investigations,
 a **human-in-the-loop approval gate** on every write, a **memory + reflexion**
 layer that recalls past incidents and promotes verified fixes, and an **autonomy**
 layer that opens its own investigations when a detector fires. See

--- a/v4/docs/glossary.md
+++ b/v4/docs/glossary.md
@@ -18,7 +18,7 @@ page where the concept is explained in depth.
 | **Memory loader** | The step that loads pinned, cross-session context (user prefs, past root causes, failure hints) into the prompt. Active only on PostgreSQL. |
 | **Cluster snapshot** | The pre-fetched picture of cluster health (pod list + Warning events) built at the start of every turn. Drives playbook matching and the snapshot sufficiency gate. |
 | **Snapshot sufficiency gate** | A soft bias that lets the agent answer healthy, list-shaped questions straight from the snapshot instead of re-querying. Modes: `off` / `lenient` / `strict`. See [Agent Behaviors](agent-behaviors.md#snapshot-sufficiency-gate). |
-| **Playbook** | A YAML investigation recipe for a known failure (CrashLoopBackOff, OOMKilled, …). When the snapshot matches, the playbook is injected into the prompt to guide the agent. 23 ship by default. See [Playbook library](agent-behaviors.md#playbook-library). |
+| **Playbook** | A YAML investigation recipe for a known failure (CrashLoopBackOff, OOMKilled, …). When the snapshot matches, the playbook is injected into the prompt to guide the agent. 24 ship by default. See [Playbook library](agent-behaviors.md#playbook-library). |
 | **Investigation plan** | A visible, up-front checklist the agent emits for queries needing 3+ steps, streamed as a `plan` event so the UI can show it. |
 | **RCA** | **Root-Cause Analysis** — the deep investigation path where four subagents run in parallel and the coordinator synthesizes their findings into one conclusion. |
 | **RCAResult** | The structured output of an RCA: root cause, confidence, supporting evidence, conflicting evidence, reasoning, and a recommended fix. See [What you can ask](capabilities.md#what-a-root-cause-answer-looks-like). |

--- a/v4/packages/kubeintellect-server/app/agent/playbooks/dns_resolution_failure.yaml
+++ b/v4/packages/kubeintellect-server/app/agent/playbooks/dns_resolution_failure.yaml
@@ -1,0 +1,35 @@
+name: DnsResolutionFailure
+# DNS failures surface in APPLICATION logs ("no such host", "Temporary
+# failure in name resolution", "dial tcp: lookup ... on 10.96.0.10:53") and in
+# CoreDNS SERVFAIL logs. Neither is visible to the kubectl --watch sensorium:
+# pod STATUS stays Running and no Warning event is ever emitted, so there is
+# nothing to compile into a watch predicate. Same call NetworkPolicyBlocking
+# makes for the same reason. Detection stays prompt-side (Loki query / triage).
+detect: null
+triggers:
+  - event_message_regex: "no such host|Temporary failure in name resolution|dial tcp.*lookup|SERVFAIL|NXDOMAIN|server can't find"
+investigation_steps:
+  - "kubectl get pods -n kube-system -l k8s-app=kube-dns -o wide — confirm the CoreDNS pods are Running and Ready; if they are not, the resolver itself is down."
+  - "kubectl logs -n kube-system -l k8s-app=kube-dns --tail=50 — look for SERVFAIL or upstream timeout lines; they name the failing upstream."
+  - "kubectl get svc kube-dns -n kube-system -o yaml — confirm the Service exists and has a clusterIP; then check its endpoints: kubectl get endpoints kube-dns -n kube-system."
+  - "kubectl get pod <app-pod> -n <ns> -o yaml — inspect dnsPolicy and dnsConfig on the workload that cannot resolve; ClusterFirst is the default, None means the pod owns its resolv.conf."
+  - "kubectl get networkpolicy -A — check for an egress policy that does not admit UDP/TCP 53 to the kube-dns clusterIP; a drop here looks exactly like a dead resolver."
+  - "Probe from inside the cluster: kubectl run dns-probe --image=busybox:1.36 --restart=Never --rm -i -- nslookup kubernetes.default.svc.cluster.local — if this fails too, the problem is cluster-wide; if it succeeds, it is workload-local (dnsPolicy/dnsConfig or a policy on that namespace)."
+expected_evidence:
+  - "CoreDNS pods not Running/Ready, or CoreDNS logs containing SERVFAIL / upstream timeout"
+  - "kube-dns Service with no ready endpoints"
+  - "Workload dnsPolicy: None, or dnsConfig pointing at unreachable nameservers"
+  - "NetworkPolicy (egress or ingress) that drops traffic to port 53"
+  - "Absence check: if CoreDNS is healthy AND the Service has endpoints AND the workload uses ClusterFirst AND no policy blocks 53, look at the upstream resolvers in the Corefile and the node's /etc/resolv.conf — the fault is upstream of the cluster"
+recommended_fix_template: |
+  Pod <APP_POD> in namespace <NS> cannot resolve cluster DNS. The diagnosis
+  points at <CAUSE>:
+
+  - CoreDNS down: restore the deployment (kubectl rollout restart deployment/coredns -n kube-system, or fix whatever keeps the pods from Running).
+  - kube-dns Service broken: repair the Service selector so it matches the coredns pod labels.
+  - Workload dnsPolicy/dnsConfig wrong: patch the pod spec back to ClusterFirst (default), or fix the nameservers / ndots in dnsConfig.
+  - NetworkPolicy blocking port 53: add an egress rule to the kube-dns clusterIP, or an ingress rule to the coredns pods, scoped to the affected namespace.
+  - Upstream resolver failing: adjust the Corefile forward block or the node resolv.conf.
+
+  Remediation is NOT executed automatically — present the operator with the
+  relevant step and let the human-in-the-loop gate approve it.

--- a/v4/tests/test_every_playbook_is_reachable.py
+++ b/v4/tests/test_every_playbook_is_reachable.py
@@ -100,8 +100,8 @@ def test_every_playbook_has_a_trigger_that_could_fire(pb):
 
 def test_the_inventory_is_actually_covered():
     """Guard the guard: an empty registry would make both tests above pass vacuously."""
-    assert len(_PLAYBOOKS) == 23, f"playbook count changed to {len(_PLAYBOOKS)}"
-    assert len(_CASES) == 41, f"trigger-regex count changed to {len(_CASES)}"
+    assert len(_PLAYBOOKS) == 24, f"playbook count changed to {len(_PLAYBOOKS)}"
+    assert len(_CASES) == 42, f"trigger-regex count changed to {len(_CASES)}"
 
 
 def test_a_mistyped_trigger_key_is_exactly_the_shape_this_file_catches():

--- a/v4/tests/test_playbooks.py
+++ b/v4/tests/test_playbooks.py
@@ -69,6 +69,7 @@ def test_all_playbooks_load() -> None:
         "NodeNotReady",
         "NetworkPolicyBlocking",
         "DeploymentRolloutStuck",
+        "DnsResolutionFailure",
     }
     assert expected.issubset(names), f"missing playbooks: {expected - names}"
 
@@ -369,3 +370,33 @@ def test_playbook_yaml_is_read_as_utf8_regardless_of_locale(monkeypatch) -> None
         f"playbook YAML read without an explicit UTF-8 encoding: {read_without_utf8}"
     )
 
+
+# ── DnsResolutionFailure triggers (#96) ───────────────────────────────────────
+
+DNS_FAILURE_EVENTS = """\
+NAMESPACE   LAST SEEN   TYPE      REASON     OBJECT       MESSAGE
+default     20s         Warning   Unhealthy  pod/api-1    Get "http://svc:8080/healthz": dial tcp: lookup svc on 10.96.0.10:53: no such host
+"""
+
+
+def test_match_dns_resolution_failure_by_lookup_error() -> None:
+    matched = match_playbooks(HEALTHY_PODS, DNS_FAILURE_EVENTS)
+    assert "DnsResolutionFailure" in matched
+
+
+def test_match_dns_resolution_failure_by_temporary_resolution_failure() -> None:
+    events = (
+        "NAMESPACE   LAST SEEN  TYPE     REASON  OBJECT      MESSAGE\n"
+        "default     10s        Warning  Failed  pod/worker  Temporary failure in name resolution\n"
+    )
+    matched = match_playbooks(HEALTHY_PODS, events)
+    assert "DnsResolutionFailure" in matched
+
+
+def test_dns_resolution_failure_ignores_plain_timeouts() -> None:
+    """A plain i/o timeout is a connectivity problem — NetworkPolicyBlocking's
+    lane. A lookup failure means the name itself did not resolve; the two are
+    different failure modes and should not cross-fire.
+    """
+    matched = match_playbooks(HEALTHY_PODS, TIMEOUT_EVENTS)
+    assert "DnsResolutionFailure" not in matched


### PR DESCRIPTION
Adopts **#134 by @uuzzrm**, which was closed unmerged on 2026-08-15 in a batch with #135 and #137. Those two landed; **this one did not**, and nobody said so on the thread. That is a maintainer error, not a problem with the contribution. Their commit is carried here **unmodified, with their authorship intact**.

## The contribution

A `DnsResolutionFailure` playbook with event-message triggers for the log signatures DNS failures actually produce, plus three tests — two positive, and one proving it does **not** cross-fire with `NetworkPolicyBlocking` on a plain i/o timeout.

@uuzzrm deliberately left `detect:` null and [said why on #96](https://github.com/MSKazemi/kubeintellect/issues/96#issuecomment-3184913329): the failure shows up in application logs and CoreDNS SERVFAIL lines, neither of which reaches the kubectl watch sensorium — the pod stays `Running` with no Warning event. There was nothing honest to compile into a watch predicate. That is the correct call, it matches `NetworkPolicyBlocking`'s precedent, and given #114 (a playbook whose `detect:` block could never fire passed all nine gates) a contributor declining to invent a predicate is exactly the judgement this repo wants.

They also flagged that the upstream-resolver evidence lines were reasoned from the schema rather than observed, having no live cluster. Called out plainly, in the PR and the issue.

## Maintainer follow-up (second commit)

Only what moved underneath the branch while it sat:

- `test_the_inventory_is_actually_covered` hard-codes the counts so an empty registry cannot make the reachability tests pass vacuously. Added to `main` **after** #134 was written: 23 → 24 playbooks, 41 → 42 trigger regexes.
- `faq.md` playbook count and `AGENTS.md` server-suite count recollected by `check_doc_claims.py`.
- Two additive conflicts resolved by keeping both sides.

## Gates (Python 3.13)

| Gate | Result |
|---|---|
| `ruff check` | All checks passed |
| Server suite | 5486 passed, 23 skipped |
| playbook + reachability + RBAC | 109 passed |
| `check_doc_claims.py` | Doc claims now match the code |

Depends on #185 for a green required check.


---

*(Supersedes #186, which pointed at the pre-rebase branch. Same two commits, rebased onto `main` after #184 and #185 merged; `AGENTS.md`'s server-suite count is recollected to **5515** — the cross-PR total, since #184 and #186 each computed 5510 in isolation.)*
