### PR TITLE
docs(contributing): correct the test counts, and put them under the gate that already existed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,8 +204,8 @@ uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube
 
 # 3. Tests — two suites, run separately: the two `tests` packages collide
 #    under a single pytest invocation.
-uv run python -m pytest tests/ -q                              # server (~1,050 tests)
-cd packages/kube-q && uv run python -m pytest tests/ -q        # kq CLI (~317 tests)
+uv run python -m pytest tests/ -q                              # server (~5515 tests)
+cd packages/kube-q && uv run python -m pytest tests/ -q        # kq CLI (~749 tests)
 ```
 
 If you are fixing a bug in a frozen arm, run that arm's own suite too — it resolves from its

--- a/v4/scripts/check_doc_claims.py
+++ b/v4/scripts/check_doc_claims.py
@@ -260,9 +260,11 @@ def _measured_claims() -> tuple[list[_Claim], list[str]]:
     """
     claims: list[_Claim] = []
     notes: list[str] = []
-    for label, rootdir, pattern in (
-        ("server suite", _V4, r"Server suite \((\d+) tests\)"),
-        ("kq CLI suite", _V4 / "packages" / "kube-q", r"kq CLI suite \((\d+) tests\)"),
+    for label, rootdir, pattern, contributing in (
+        ("server suite", _V4, r"Server suite \((\d+) tests\)",
+         r"# server \(~(\d+) tests\)"),
+        ("kq CLI suite", _V4 / "packages" / "kube-q", r"kq CLI suite \((\d+) tests\)",
+         r"# kq CLI \(~(\d+) tests\)"),
     ):
         actual = _collect_count(rootdir)
         if actual is None:
@@ -272,6 +274,9 @@ def _measured_claims() -> tuple[list[_Claim], list[str]]:
             )
             continue
         claims.append(("root:AGENTS.md", pattern, actual, f"{label} test count"))
+        claims.append((
+            "root:CONTRIBUTING.md", contributing, actual, f"{label} test count (CONTRIBUTING)"
+        ))
 
     drift = _format_drift_count()
     if drift is None:


### PR DESCRIPTION
Measured against a **fresh `git clone` of the public repo** — the only way to see what a contributor actually gets — not against a working tree.

| | measured | `CONTRIBUTING.md` said | |
|---|---|---|---|
| server suite | **5515** | ~1,050 | 🔴 5× stale |
| kq CLI suite | **749** | ~317 | 🔴 2.4× stale |
| v2 | 259 | ~259 | ✅ |
| v3 | 154 | ~154 | ✅ |

The two **frozen** trees are correct precisely because frozen code cannot drift. The two live ones rotted.

A newcomer who follows the onboarding page, runs the suite and sees 5515 where it promised ~1,050 cannot tell whether they ran the wrong thing, cloned the wrong thing, or the doc is stale. That is a bad first five minutes, on the page whose whole job is the first five minutes.

## This also retires a stale internal assumption

Our notes from August recorded that the public clone had a *subset* of the suite (86 test files, 1047 tests) and that `AGENTS.md`'s larger number was a private count that must never be published as-is. **That is no longer true.** The fresh public clone carries **279 test files and collects 5515** — exactly what `AGENTS.md` says. So the two public documents simply disagreed with each other by 5×, and `AGENTS.md` was the correct one.

## The structural fix

`AGENTS.md`'s counts have been gated by `check_doc_claims.py` ever since the drift that produced 990-vs-1031. `CONTRIBUTING.md`'s were gated by **nothing** — which is exactly why one rotted and the other stayed exact.

Both now ride the same `_measured_claims()` collection that already runs for `AGENTS.md` — **one collection, two documents** — so `make docs-fix` repairs them together and CI fails if either drifts again.

## Verified red-green, not assumed

Reintroducing `~1050`:

```
FAIL root:CONTRIBUTING.md: server suite test count (CONTRIBUTING) says 1050,
     code says 5515 (/# server \(~(\d+) tests\)/)
```

and `--fix` rewrites it back. Numbers are plain digits so the fixer can replace capture group 1; the `~` stays because the count is still approximate between runs.

## Gates

`check_doc_claims.py` clean · `ruff` clean · `test_doc_claims.py` **22 passed** · full server suite **5492 passed / 23 skipped**.