### PR TITLE
fix(config): the anthropic fallback warning now names the vendor that gets the data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ uv run ruff check packages/kubeintellect-server/app/ packages/ki-protocol/ packa
 # 2. Types — the workspace is at ZERO errors; keep it there.
 uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube-q/kube_q
 
-# 3. Server suite (5515 tests)
+# 3. Server suite (5520 tests)
 uv run python -m pytest tests/ -q
 
 # 4. kq CLI suite (749 tests)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube
 
 # 3. Tests — two suites, run separately: the two `tests` packages collide
 #    under a single pytest invocation.
-uv run python -m pytest tests/ -q                              # server (~5515 tests)
+uv run python -m pytest tests/ -q                              # server (~5520 tests)
 cd packages/kube-q && uv run python -m pytest tests/ -q        # kq CLI (~749 tests)
 ```
 

--- a/v4/packages/kubeintellect-server/app/core/config.py
+++ b/v4/packages/kubeintellect-server/app/core/config.py
@@ -743,9 +743,21 @@ class Settings(BaseSettings):
                 self.OPENAI_SUBAGENT_MODEL = "qwen-plus"
         if self.LLM_PROVIDER == "anthropic":
             if not self.CORTEX_V4_ENABLED:
+                # Name the CONSEQUENCE, not just the cause. The previous wording --
+                # "anthropic is only used by the V4 cortex" -- reads as "Anthropic will not
+                # be used", i.e. it will fail or do nothing. What actually happens is that
+                # the default V2 graph builds a ChatOpenAI client and sends every prompt,
+                # cluster data included, to OpenAI using OPENAI_API_KEY. Provider choice is
+                # often a compliance decision, so a reader deciding whether to act on this
+                # line needs to know which vendor receives the data.
                 logging.warning(
-                    "LLM_PROVIDER=anthropic is only used by the V4 cortex — "
-                    "set CORTEX_V4_ENABLED=true (the V2 graph supports azure/openai only)."
+                    "LLM_PROVIDER=anthropic but CORTEX_V4_ENABLED is false. The default V2 "
+                    "graph has no Anthropic backend, so every coordinator and subagent call "
+                    "-- including the cluster data in each prompt -- will be sent to OpenAI "
+                    "at %s using OPENAI_API_KEY, not to Anthropic, and ANTHROPIC_API_KEY "
+                    "will be ignored. Set CORTEX_V4_ENABLED=true to actually use Anthropic, "
+                    "or set LLM_PROVIDER=openai to make the current behaviour explicit.",
+                    self.OPENAI_BASE_URL or "https://api.openai.com/v1",
                 )
             if not self.ANTHROPIC_API_KEY:
                 logging.warning(

--- a/v4/tests/test_the_anthropic_warning_names_the_vendor_that_gets_the_data.py
+++ b/v4/tests/test_the_anthropic_warning_names_the_vendor_that_gets_the_data.py
@@ -1,0 +1,71 @@
+"""`LLM_PROVIDER=anthropic` on the default graph routes to OpenAI — say so, in those words.
+
+The V2 graph (the default; `CORTEX_V4_ENABLED` is false) has no Anthropic backend, so
+`app.core.llm._coordinator_llm` falls through to `_make_openai`. A user who selected
+`anthropic` therefore gets a `ChatOpenAI` client talking to `api.openai.com` with
+`OPENAI_API_KEY`, and their `ANTHROPIC_API_KEY` is never read.
+
+That behaviour is deliberate and it is warned about. What this file pins is the *wording*:
+the warning must name the vendor that receives the data. The previous text said only that
+`anthropic` "is only used by the V4 cortex", which reads as *Anthropic will not be used* --
+true, but it is the cause, not the consequence, and it leaves a reader believing the run will
+fail rather than succeed against a different provider. Provider choice is frequently a
+compliance decision (see `v4/docs/data-handling.md` and discussion #83), so the identity of
+the receiving vendor is the load-bearing fact, not the name of the graph.
+
+See issue #192. Deleting `OpenAI` from that message must fail this file.
+"""
+from __future__ import annotations
+
+import logging
+
+from app.core.config import Settings
+
+
+def _settings(**kw) -> Settings:
+    # _env_file=None isolates the test from a developer's real v4/.env
+    return Settings(_env_file=None, **kw)
+
+
+class TestTheAnthropicFallbackWarning:
+    def _warn(self, caplog, **kw) -> str:
+        with caplog.at_level(logging.WARNING):
+            _settings(
+                LLM_PROVIDER="anthropic",
+                ANTHROPIC_API_KEY="sk-ant-x",
+                OPENAI_API_KEY="sk-openai-x",
+                CORTEX_V4_ENABLED=False,
+                **kw,
+            )
+        return "\n".join(r.getMessage() for r in caplog.records)
+
+    def test_it_names_openai_as_the_recipient(self, caplog):
+        text = self._warn(caplog)
+        assert "OpenAI" in text, (
+            "the warning must name the vendor that actually receives the cluster data; "
+            f"got: {text!r}"
+        )
+
+    def test_it_names_the_credential_that_is_actually_used(self, caplog):
+        text = self._warn(caplog)
+        assert "OPENAI_API_KEY" in text
+        assert "ANTHROPIC_API_KEY" in text, "say that the Anthropic key is ignored"
+
+    def test_it_names_the_endpoint_including_a_custom_base_url(self, caplog):
+        """A self-hosted OPENAI_BASE_URL changes who receives the data — report the real one."""
+        text = self._warn(caplog, OPENAI_BASE_URL="https://llm.internal.example/v1")
+        assert "https://llm.internal.example/v1" in text
+        assert "api.openai.com" not in text
+
+    def test_the_default_endpoint_is_named_when_no_base_url_is_set(self, caplog):
+        assert "https://api.openai.com/v1" in self._warn(caplog)
+
+    def test_no_warning_when_cortex_is_enabled(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            _settings(
+                LLM_PROVIDER="anthropic",
+                ANTHROPIC_API_KEY="sk-ant-x",
+                CORTEX_V4_ENABLED=True,
+            )
+        joined = "\n".join(r.getMessage() for r in caplog.records)
+        assert "will be sent to OpenAI" not in joined


### PR DESCRIPTION
Partial fix for #192 — the cheap half, worth doing whichever way the larger decision goes.

## What happens today

`LLM_PROVIDER=anthropic` with `CORTEX_V4_ENABLED=false` (the default) builds a **ChatOpenAI** client:

```
client class : langchain_openai.chat_models.base.ChatOpenAI
model        : gpt-4o                  (not claude-sonnet-4-6)
base_url     : https://api.openai.com/v1
api key used : OPENAI_API_KEY          (ANTHROPIC_API_KEY never read)
```

**This was already warned about** — so this is not "nobody noticed". The warning said the provider *"is only used by the V4 cortex"*, which is the **cause**, not the **consequence**. It reads as *"Anthropic will not be used"* — i.e. the run will fail or do nothing. What actually happens is the run **succeeds against a different vendor**, and the message never named which one.

That distinction is load-bearing rather than pedantic: provider choice is frequently a **compliance** decision (`v4/docs/data-handling.md`, discussion #83), so the receiving vendor's identity is exactly the fact a reader needs. And it only surfaces when `OPENAI_API_KEY` is unset — when it is set, which is common, everything works fine against the wrong vendor.

## The change

The message now names OpenAI, the **resolved endpoint** (honouring a custom `OPENAI_BASE_URL`, since a self-hosted endpoint changes who receives the data), `OPENAI_API_KEY` as the credential actually used, and `ANTHROPIC_API_KEY` as the one ignored.

Five tests pin the wording. Against the previous message:

```
4 failed, 1 passed     # before
5 passed               # after
```

Deleting `OpenAI` from that message fails the file.

## Deliberately not addressed here

Left on #192 for a considered decision:
- whether this should **refuse to start** rather than warn — an *unknown* provider already raises, while a *known* provider that routes to a different vendor only logs;
- whether `core/llm.py` should implement Anthropic the way `cortex/models.py` already does.

**Nothing about the Cortex path changes.**

## Gates

`ruff` clean · `mypy` 0 errors / 193 files · server suite **5497 passed / 23 skipped** · doc-claims recollected 5515 → 5520 in *both* `AGENTS.md` and `CONTRIBUTING.md` (the shared collection added in #191 doing its job).