### PR TITLE
fix(detectors): correct the unevaluated-promql count, and gate it so it cannot rot again

### DIFF
--- a/v4/packages/kubeintellect-server/app/detectors/models.py
+++ b/v4/packages/kubeintellect-server/app/detectors/models.py
@@ -218,7 +218,7 @@ def parse_detect_block(playbook_name: str, raw: dict | None) -> DetectBlock | No
     # pass the schema check, and then never fire. That is the same trap the
     # `kind:` warning in docs/agent-behaviors.md documents.
     #
-    # The 21 `promql:` queries in the shipped playbooks all sit alongside real
+    # The 19 `promql:` queries in the shipped playbooks all sit alongside real
     # `watch_predicates`, so nothing that fires today stops firing; what is not
     # true is the extra coverage those queries appear to claim.
     if not predicates and not trends:

--- a/v4/scripts/check_doc_claims.py
+++ b/v4/scripts/check_doc_claims.py
@@ -43,6 +43,7 @@ class Canonical:
     detector_count: int
     providers: set[str]
     flag_count: int
+    promql_count: int
 
 
 def _canonical() -> Canonical:
@@ -71,11 +72,25 @@ def _canonical() -> Canonical:
         if name.startswith(("KI_V5_", "CORTEX_V5_"))
     )
 
+    # `promql:` declarations across the shipped playbooks. Counted from the YAML the
+    # loader actually reads, because the number is quoted in a *safety* comment in
+    # `detectors/models.py` explaining why a promql-only detector is refused — and that
+    # comment said 21 while the tree carried 19, from 2026-08-23 until it was gated here.
+    # A number living in a source comment is exactly the kind no gate was watching.
+    playbook_dir = (
+        _ROOT / "v4" / "packages" / "kubeintellect-server" / "app" / "agent" / "playbooks"
+    )
+    promql_count = sum(
+        len(re.findall(r"^\s*promql:", f.read_text(encoding="utf-8"), re.M))
+        for f in sorted(playbook_dir.glob("*.yaml"))
+    )
+
     return Canonical(
         playbook_count=playbook_count,
         detector_count=detector_count,
         providers=providers,
         flag_count=flag_count,
+        promql_count=promql_count,
     )
 
 
@@ -299,6 +314,12 @@ def _numeric_claims(c: Canonical) -> list[_Claim]:
     """
     pc, dc, fc = c.playbook_count, c.detector_count, c.flag_count
     return [
+        # A safety comment, not a doc: it explains why a promql-only detector is refused.
+        # It is checked here because it is a number about the tree, and nothing else was
+        # watching it -- it read 21 against a tree of 19 for over two weeks.
+        ("root:v4/packages/kubeintellect-server/app/detectors/models.py",
+         r"The (\d+) `promql:` queries in the shipped playbooks", c.promql_count,
+         "unevaluated promql count"),
         ("agent-behaviors.md", r"Playbooks shipped \((\d+)\)", pc, "playbook count"),
         ("agent-behaviors.md", r"Of the (\d+) shipped playbooks", pc, "playbook count"),
         ("capabilities.md", r"the (\d+) most common failures", pc, "playbook count"),


### PR DESCRIPTION
`detectors/models.py` carries a **safety comment** explaining why a detector declaring only `promql` predicates is refused — nothing evaluates `DetectBlock.promql`, so such a detector would load, count toward the detector total, pass the schema check, and **never fire**.

It quantified the blast radius as:

> The **21** `promql:` queries in the shipped playbooks all sit alongside real `watch_predicates`…

**The tree carries 19.** It was already 19 at `b346910` (2026-08-27) when that comment was last edited, and the "21" text dates from `1f54c19` on 2026-08-23 — so the number has been wrong for over two weeks, inside the comment that justifies a safety refusal.

## The count was never the danger — the blind spot was

The surrounding reasoning is correct and unchanged. What matters is that this is a **number about the tree living in a source comment**, which is exactly the shape no gate was watching. `check_doc_claims.py` covered `v4/docs/`, `ROADMAP.md`, `AGENTS.md`, and (since #191) `CONTRIBUTING.md` — and stopped at the file boundary.

So rather than only correcting 21 → 19, **the count now rides the same claim table**. The `root:` prefix already resolved from the repo root, so pointing a claim at a source file needed no new machinery — just a `promql_count` on `Canonical`, derived from the YAML the loader actually reads.

## Verified red-green

Before:

```
FAIL root:v4/packages/kubeintellect-server/app/detectors/models.py:
     unevaluated promql count says 21, code says 19
```

`--fix` rewrites it. Adding or removing a `promql:` from any playbook now moves a **gated** number instead of silently invalidating a safety comment.

## Gates

`ruff` clean · `mypy` 0 errors / 193 files · `test_doc_claims.py` **22 passed** · full server suite **5497 passed / 23 skipped**.