### PR TITLE
fix(kubectl): a rollback point marked `restorable` now covers the whole command (#190)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ uv run ruff check packages/kubeintellect-server/app/ packages/ki-protocol/ packa
 # 2. Types — the workspace is at ZERO errors; keep it there.
 uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube-q/kube_q
 
-# 3. Server suite (5520 tests)
+# 3. Server suite (5529 tests)
 uv run python -m pytest tests/ -q
 
 # 4. kq CLI suite (749 tests)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube
 
 # 3. Tests — two suites, run separately: the two `tests` packages collide
 #    under a single pytest invocation.
-uv run python -m pytest tests/ -q                              # server (~5520 tests)
+uv run python -m pytest tests/ -q                              # server (~5529 tests)
 cd packages/kube-q && uv run python -m pytest tests/ -q        # kq CLI (~749 tests)
 ```
 

--- a/v4/packages/ki-protocol/ki_protocol/record.py
+++ b/v4/packages/ki-protocol/ki_protocol/record.py
@@ -50,8 +50,14 @@ def summarise_record(kind: str, payload: dict[str, Any]) -> str:
         return f"result: {str(p.get('summary') or p.get('output', '')).strip()[:100]}"
     if kind == "rollback_point":
         state = p.get("restorable")
-        mark = "" if state is True else (
-            " ⚠️ NOT restorable" if state is False else " (restorability not recorded)")
+        # An incomplete capture is not restorable (#190), so say how much of the command it
+        # actually covers -- "NOT restorable" alone reads as "the bytes are damaged", which is
+        # a different and less alarming problem than "this covers 3 of the 7 objects".
+        got, want = p.get("targets_captured"), p.get("targets_intended")
+        scope = f" [{got}/{want} objects]" if isinstance(got, int) and isinstance(want, int) else ""
+        mark = scope if state is True else (
+            f" ⚠️ NOT restorable{scope}" if state is False
+            else f" (restorability not recorded){scope}")
         return (f"rollback point {p.get('rollback_id', '')}{mark} before: "
                 f"{str(p.get('command', ''))[:80]}")
     if kind == "hitl_request":

--- a/v4/packages/kubeintellect-server/app/tools/kubectl_tool.py
+++ b/v4/packages/kubeintellect-server/app/tools/kubectl_tool.py
@@ -975,6 +975,10 @@ _SUBCOMMAND_VERBS = frozenset({"rollout"})
 # Size cap for one captured pre-state. Anything larger is truncated, and a truncated object is
 # not a restore point — the capture records that rather than letting it pass as one.
 _ROLLBACK_MAX_CHARS = 4000
+# How many objects one rollback point will fetch. The cap bounds latency on a large
+# `apply -f -`; it was previously an unnamed `[:5]` slice, so objects past it were
+# dropped with nothing recording that the capture was partial (#190).
+_ROLLBACK_MAX_TARGETS = 5
 
 
 def _external_manifest_source(verb: str, args: list[str]) -> str | None:
@@ -1317,6 +1321,7 @@ def _capture_rollback_point(verb: str, args: list, stdin: str | None, config, en
         from app.utils.redact import redact_secrets
 
         targets: list[list[str]] = []
+        parse_error: str | None = None
         if stdin:
             try:
                 for doc in yaml.safe_load_all(stdin):
@@ -1330,8 +1335,10 @@ def _capture_rollback_point(verb: str, args: list, stdin: str | None, config, en
                         if ns:
                             target += ["-n", ns]
                         targets.append(target)
-            except Exception:
-                pass
+            except Exception as exc:
+                # A parse that dies half-way leaves `targets` covering only the documents
+                # read so far. Swallowing that produced a capture that looked whole.
+                parse_error = str(exc)[:200]
         else:
             # delete/patch/scale/label with explicit resource args:
             # swap the verb for `get ... -o yaml`, drop value-bearing flags.
@@ -1371,7 +1378,20 @@ def _capture_rollback_point(verb: str, args: list, stdin: str | None, config, en
         states = []
         notes: list[str] = []
         restorable = True
-        for target in targets[:5]:
+
+        # `restorable` answers two independent questions, and until #190 it only answered the
+        # first: is what we captured FAITHFUL (survived redaction and the cap), and does it
+        # COVER every object the command will touch. A capture can be perfectly faithful and
+        # still hold 3 of 7 objects, and the operator applying it would restore a subset while
+        # believing they restored everything. So every object that drops out is counted and
+        # named, and an incomplete capture is not restorable however clean its bytes are.
+        intended = len(targets)
+        if parse_error:
+            notes.append(f"stdin: manifest parse failed ({parse_error}) — object list is partial")
+            restorable = False
+
+        for target in targets[:_ROLLBACK_MAX_TARGETS]:
+            label = " ".join(target[2:4])
             try:
                 pre = subprocess.run(
                     target, capture_output=True, text=True, timeout=5, env=env, shell=False
@@ -1382,13 +1402,27 @@ def _capture_rollback_point(verb: str, args: list, stdin: str | None, config, en
                     # the object, so it must not cost a capture its restorable flag.
                     if kept.rstrip("\n") != pre.stdout.rstrip("\n"):
                         restorable = False
-                        notes.append(f"{' '.join(target[2:4])}: "
+                        notes.append(f"{label}: "
                                      f"{_capture_note(pre.stdout, kept, _ROLLBACK_MAX_CHARS)}")
                     states.append(kept)
-            except Exception:
-                continue
+                else:
+                    reason = (pre.stderr or "").strip().splitlines()
+                    notes.append(
+                        f"{label}: not captured — kubectl exited {pre.returncode}"
+                        + (f": {redact_secrets(reason[0], max_chars=200)}" if reason else "")
+                    )
+            except Exception as exc:
+                notes.append(f"{label}: not captured — {type(exc).__name__}")
+        if len(targets) > _ROLLBACK_MAX_TARGETS:
+            notes.append(
+                f"{len(targets) - _ROLLBACK_MAX_TARGETS} further object(s) were never attempted "
+                f"— the capture is capped at {_ROLLBACK_MAX_TARGETS}"
+            )
         if not states:
             return
+        captured = len(states)
+        if captured != intended:
+            restorable = False
         session_id = (config.get("configurable") or {}).get("thread_id", "-") if config else "-"
         rollback_id = f"rb-{_uuid.uuid4().hex[:12]}"
         flight_recorder.record(session_id, "rollback_point", {
@@ -1397,14 +1431,18 @@ def _capture_rollback_point(verb: str, args: list, stdin: str | None, config, en
             "command": " ".join(str(a) for a in args)[:300],
             "pre_state": states,
             "restorable": restorable,
+            "targets_intended": intended,
+            "targets_captured": captured,
             "capture_notes": notes,
             "session_id": session_id,
         })
         if restorable:
-            logger.info(f"rollback_point_armed id={rollback_id} targets={len(states)}")
+            logger.info(
+                f"rollback_point_armed id={rollback_id} targets={captured}/{intended}"
+            )
         else:
             logger.warning(
-                f"rollback_point_recorded id={rollback_id} targets={len(states)} — "
+                f"rollback_point_recorded id={rollback_id} targets={captured}/{intended} — "
                 f"NOT restorable, do not apply it: {'; '.join(notes)}"
             )
     except Exception as exc:

--- a/v4/tests/test_a_rollback_point_covers_every_object_or_says_it_does_not.py
+++ b/v4/tests/test_a_rollback_point_covers_every_object_or_says_it_does_not.py
@@ -1,0 +1,137 @@
+"""A rollback point marked `restorable` must cover every object the command mutates.
+
+`restorable` answers two independent questions, and before #190 it only answered the first:
+
+1. is what we captured **faithful** — did the YAML survive redaction and the size cap intact;
+2. does it **cover** every object the command will touch.
+
+A capture can be perfectly faithful and still hold 3 of 7 objects. Nothing recorded the gap:
+`restorable` stayed `True` and `capture_notes` stayed empty, so `ki_protocol/record.py` printed
+no warning mark and the postmortem counted it as restorable. Someone recovering from an incident
+would restore a subset believing they had restored everything -- safety invariant #1 (never
+report a result you do not have), at the rollback layer.
+
+Four independent ways an object drops out, each covered below:
+
+* the `_ROLLBACK_MAX_TARGETS` cap, which was an unnamed `[:5]` slice;
+* `kubectl get` exiting non-zero (deleted since, RBAC, wrong context);
+* the fetch raising -- a 5s timeout is not generous on a loaded apiserver;
+* the stdin manifest failing to parse half-way, leaving a partial object list.
+
+`_capture_rollback_point` is best-effort **by contract and must never raise**; the last test
+pins that, because everything above adds work to a function whose failure mode is silence.
+"""
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from app.db import flight_recorder
+from app.tools import kubectl_tool as kt
+
+_OK_YAML = "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {name}\ndata:\n  k: v\n"
+
+
+def _manifest(n: int) -> str:
+    return "\n---\n".join(
+        f"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm{i}\n  namespace: prod\ndata:\n  k: v{i}\n"
+        for i in range(n)
+    )
+
+
+def _capture(monkeypatch, manifest: str, runner) -> dict | None:
+    recorded: list[dict] = []
+    with patch.object(kt.subprocess, "run", runner), \
+         patch.object(flight_recorder, "record", lambda sid, kind, payload: recorded.append(payload)):
+        kt._capture_rollback_point("apply", ["apply", "-f", "-"], manifest, None, {})
+    return recorded[0] if recorded else None
+
+
+def _all_ok(cmd, **kw):
+    return subprocess.CompletedProcess(cmd, 0, _OK_YAML.format(name=cmd[3]), "")
+
+
+class TestAnIncompleteCaptureIsNotRestorable:
+    def test_a_capture_of_every_object_is_restorable(self, monkeypatch):
+        p = _capture(monkeypatch, _manifest(3), _all_ok)
+        assert p["restorable"] is True
+        assert (p["targets_intended"], p["targets_captured"]) == (3, 3)
+        assert p["capture_notes"] == []
+
+    def test_objects_past_the_cap_are_counted_and_named(self, monkeypatch):
+        p = _capture(monkeypatch, _manifest(7), _all_ok)
+        assert p["restorable"] is False, "5 of 7 objects is not a restore point"
+        assert (p["targets_intended"], p["targets_captured"]) == (7, 5)
+        assert any("never attempted" in n for n in p["capture_notes"])
+
+    def test_a_failed_kubectl_get_is_counted_and_named(self, monkeypatch):
+        def runner(cmd, **kw):
+            if cmd[3] == "cm1":
+                return subprocess.CompletedProcess(cmd, 1, "", "Error from server (NotFound)")
+            return _all_ok(cmd, **kw)
+
+        p = _capture(monkeypatch, _manifest(3), runner)
+        assert p["restorable"] is False
+        assert (p["targets_intended"], p["targets_captured"]) == (3, 2)
+        assert any("cm1" in n and "exited 1" in n for n in p["capture_notes"])
+
+    def test_a_fetch_that_raises_is_counted_and_named(self, monkeypatch):
+        def runner(cmd, **kw):
+            if cmd[3] == "cm2":
+                raise subprocess.TimeoutExpired(cmd, 5)
+            return _all_ok(cmd, **kw)
+
+        p = _capture(monkeypatch, _manifest(3), runner)
+        assert p["restorable"] is False
+        assert (p["targets_intended"], p["targets_captured"]) == (3, 2)
+        assert any("cm2" in n and "TimeoutExpired" in n for n in p["capture_notes"])
+
+    def test_a_half_parsed_manifest_is_not_restorable(self, monkeypatch):
+        """A manifest that dies mid-parse yields a partial object list, not a whole one."""
+        broken = _manifest(2) + "\n---\n" + "kind: ConfigMap\n  bad: [indent\n"
+        p = _capture(monkeypatch, broken, _all_ok)
+        assert p is not None
+        assert p["restorable"] is False
+        assert any("parse failed" in n for n in p["capture_notes"])
+
+    def test_the_error_text_of_a_failed_get_is_redacted(self, monkeypatch):
+        secret = "sk-test-abcdefghijklmnopqrstuvwxyz123456"
+
+        def runner(cmd, **kw):
+            if cmd[3] == "cm1":
+                return subprocess.CompletedProcess(cmd, 1, "", f"error: token={secret} rejected")
+            return _all_ok(cmd, **kw)
+
+        p = _capture(monkeypatch, _manifest(2), runner)
+        assert secret not in "\n".join(p["capture_notes"])
+
+
+class TestTheContractThatMustNotRegress:
+    def test_redaction_damage_still_costs_restorability(self, monkeypatch):
+        """The original meaning of `restorable` — fidelity — must still hold."""
+        def runner(cmd, **kw):
+            return subprocess.CompletedProcess(
+                cmd, 0, "apiVersion: v1\nkind: Secret\nmetadata:\n  name: s\ndata:\n  password: hunter2\n", ""
+            )
+
+        p = _capture(monkeypatch, _manifest(1), runner)
+        assert p["restorable"] is False
+        assert p["capture_notes"], "a damaged capture must say so"
+
+    def test_it_never_raises_even_when_the_recorder_explodes(self, monkeypatch):
+        """Best-effort by contract: a capture failure must not break the mutation path."""
+        def boom(*a, **kw):
+            raise RuntimeError("flight recorder is down")
+
+        with patch.object(kt.subprocess, "run", _all_ok), \
+             patch.object(flight_recorder, "record", boom):
+            kt._capture_rollback_point("apply", ["apply", "-f", "-"], _manifest(2), None, {})
+
+    def test_it_never_raises_when_every_fetch_fails(self, monkeypatch):
+        def runner(cmd, **kw):
+            raise OSError("no kubectl")
+
+        assert _capture(monkeypatch, _manifest(3), runner) is None, (
+            "nothing captured means nothing recorded — a rollback point of zero objects "
+            "would be worse than none"
+        )


### PR DESCRIPTION
Fixes #190.

`restorable` answers **two** independent questions and only ever answered the first: is the captured YAML **faithful** (survived redaction and the size cap), and does it **cover** every object the command will touch.

A capture can be perfectly faithful and hold 3 of 7 objects. Nothing recorded the gap — `restorable` stayed `True`, `capture_notes` stayed empty, `record.py` printed no warning mark, and the postmortem counted it as restorable. Someone recovering from an incident would restore a subset believing they had restored everything. Safety invariant #1, at the rollback layer.

## Measured — `apply -f -` with 7 ConfigMaps, one deleted since, one timing out

**Before**
```
restorable      : True
pre_state count : 3
capture_notes   : []
```

**After**
```
restorable       : False
targets_intended : 7
targets_captured : 3
capture_notes:
  - configmap cm1: not captured — kubectl exited 1: Error from server (NotFound)
  - configmap cm2: not captured — TimeoutExpired
  - 2 further object(s) were never attempted — the capture is capped at 5
```

## Four ways an object dropped out — all now counted and named

| | before |
|---|---|
| the cap | an unnamed `[:5]` slice; now `_ROLLBACK_MAX_TARGETS`, overflow reported |
| `kubectl get` non-zero | no `else` on the `returncode == 0` branch |
| the fetch raising | `except Exception: continue` dropped it silently |
| **manifest half-parsed** | `except Exception: pass` hid it — **not in the issue**, found while fixing the other three |

stderr in a note goes through `redact_secrets` first.

`record.py` now prints coverage alongside the mark, because *"NOT restorable"* alone reads as *"the bytes are damaged"* — a different and less alarming problem than *"this covers 3 of the 7 objects"*.

## Tests

Nine; **five fail against the unpatched function**. Two pin contracts that must not regress:

- redaction damage still costs restorability (the original meaning of the flag);
- `_capture_rollback_point` still **never raises** — it is best-effort by contract, and every change here adds work to a function whose failure mode is silence.

## Gates

`ruff` clean · `mypy` 0 errors / 193 files · server suite **5506 passed / 23 skipped** · kq suite **749 passed** · ki-protocol parity **331 passed** · doc claims recollected to 5529.