### PR TITLE
feat(playbooks): add PDB-blocked eviction triage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ uv run ruff check packages/kubeintellect-server/app/ packages/ki-protocol/ packa
 # 2. Types — the workspace is at ZERO errors; keep it there.
 uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube-q/kube_q
 
-# 3. Server suite (5520 tests)
+# 3. Server suite (5533 tests)
 uv run python -m pytest tests/ -q
 
 # 4. kq CLI suite (749 tests)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube
 
 # 3. Tests — two suites, run separately: the two `tests` packages collide
 #    under a single pytest invocation.
-uv run python -m pytest tests/ -q                              # server (~5520 tests)
+uv run python -m pytest tests/ -q                              # server (~5533 tests)
 cd packages/kube-q && uv run python -m pytest tests/ -q        # kq CLI (~749 tests)
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,7 @@ The `v4/` platform is the current line and the only one you should deploy.
 - Conversational diagnosis correlating **kubectl + Prometheus + Loki**.
 - **Human-in-the-loop approval gate** with RBAC (superadmin / admin / operator / readonly) on
   every mutating action, enforced server-side at the mutating chokepoint.
-- **24 declarative failure playbooks** (`detect → investigate → remediate`), 20 of which compile
+- **25 declarative failure playbooks** (`detect → investigate → remediate`), 20 of which compile
   to zero-token detectors.
 - **Zero-token detection** — a detector engine over a kubectl `--watch` sensorium fires
   findings without invoking the LLM.
@@ -51,7 +51,7 @@ These are concrete, scoped, and mostly open to contribution.
 | **Composable detectors** — AND / NOT / temporal windows | Open | [#21](https://github.com/MSKazemi/kubeintellect/issues/21) ✅ |
 | **PromQL execution in playbook `detect` blocks** | Open | [#20](https://github.com/MSKazemi/kubeintellect/issues/20) ✅ |
 | **Temporal KG ingesting nodes / events / PVCs** | Open | [#19](https://github.com/MSKazemi/kubeintellect/issues/19) ✅ |
-| Grow the **playbook library** beyond 24 | Ongoing — a playbook is one YAML file; 18 → 23 in Aug 2026 via [#108](https://github.com/MSKazemi/kubeintellect/pull/108), [#112](https://github.com/MSKazemi/kubeintellect/pull/112), [#114](https://github.com/MSKazemi/kubeintellect/pull/114), [#127](https://github.com/MSKazemi/kubeintellect/pull/127) and [#128](https://github.com/MSKazemi/kubeintellect/pull/128) | [#13](https://github.com/MSKazemi/kubeintellect/issues/13) ✅ |
+| Grow the **playbook library** beyond 25 | Ongoing — a playbook is one YAML file; 18 → 23 in Aug 2026 via [#108](https://github.com/MSKazemi/kubeintellect/pull/108), [#112](https://github.com/MSKazemi/kubeintellect/pull/112), [#114](https://github.com/MSKazemi/kubeintellect/pull/114), [#127](https://github.com/MSKazemi/kubeintellect/pull/127) and [#128](https://github.com/MSKazemi/kubeintellect/pull/128) | [#13](https://github.com/MSKazemi/kubeintellect/issues/13) ✅ |
 
 ## Housekeeping — known debt, stated plainly
 

--- a/v4/deploy/helm/kubeintellect/templates/rbac.yaml
+++ b/v4/deploy/helm/kubeintellect/templates/rbac.yaml
@@ -45,6 +45,10 @@ rules:
     - statefulsets
     - replicasets
   verbs: ["get", "list", "watch"]
+# PodDisruptionBudgetBlocking needs selector and status evidence, never write access.
+- apiGroups: ["policy"]
+  resources: ["poddisruptionbudgets"]
+  verbs: ["get", "list", "watch"]
 # HPANotScaling reads the HPA's status conditions — the whole playbook is about them.
 - apiGroups: ["autoscaling"]
   resources: ["horizontalpodautoscalers"]
@@ -97,6 +101,9 @@ rules:
 # for. Nothing reported it: `helm install` succeeded, `kubeintellect status` was green, and
 # the playbook count said 23. `tests/test_rbac_covers_the_playbooks.py` now derives this
 # list from the playbooks instead of trusting it.
+- apiGroups: ["policy"]
+  resources: ["poddisruptionbudgets"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["autoscaling"]
   resources: ["horizontalpodautoscalers"]
   verbs: ["get", "list", "watch"]

--- a/v4/docs/agent-behaviors.md
+++ b/v4/docs/agent-behaviors.md
@@ -236,7 +236,7 @@ detects a matching pattern in the snapshot, the coordinator's system prompt
 includes the playbook(s) inline — guiding it to follow proven steps before
 improvising.
 
-**Playbooks shipped (24):**
+**Playbooks shipped (25):**
 
 *Pod / container lifecycle*
 
@@ -545,6 +545,14 @@ triggers:
 - `detect: null` marks a playbook as **LLM-only** (no machine signal exists,
   or the signal is owned by another playbook).
 
+`PodDisruptionBudgetBlocking` is a triage-only guide for a confirmed blocked
+voluntary eviction. Its text triggers recognize a PDB-specific eviction refusal
+or Karpenter's PDB blocker message when supplied to the matcher. The default
+Warning-only snapshot does not collect drain stderr or Karpenter's Normal events,
+so this playbook does **not** provide automatic detection of every blocked drain.
+It requires current budget, selector and readiness evidence before suggesting a
+change; zero allowed disruptions by itself can be intentional availability policy.
+
 !!! warning "A tuning knob set to `0` used to be read as *absent*"
     Every trend-predicate knob was parsed as `entry.get(key) or default`, which cannot tell
     "not set" from "set to zero" — so an author who wrote `0` silently got the default, and
@@ -669,7 +677,7 @@ triggers:
     threshold on the first scrape. That depends on runtime values, so it belongs to a
     shadow period and a human, not to a validator.
 
-Of the 24 shipped playbooks, **20 compile to detectors**; 4 are LLM-only
+Of the 25 shipped playbooks, **20 compile to detectors**; 4 are LLM-only
 (`CommandHardcodedFailure` — disambiguated from CrashLoopBackOff only by
 reading the pod spec — `ServiceUnreachable`, `NetworkPolicyBlocking`,
 where the packet is discarded in the CNI datapath so no machine signal

--- a/v4/docs/architecture.md
+++ b/v4/docs/architecture.md
@@ -487,7 +487,7 @@ packages/
 │   │   ├── coordinator.py        — LLM decision + synthesis, tool trimmer, reflexion writes
 │   │   ├── memory_loader.py      — load pinned cluster context + failure-pattern hints
 │   │   └── subagent.py           — 4 specialist subagent runners
-│   ├── playbooks/                — YAML playbook library + loader (24 playbooks)
+│   ├── playbooks/                — YAML playbook library + loader (25 playbooks)
 │   ├── state.py                  — AgentState, SubagentInput, AgentFinding, RCAResult
 │   ├── workflow.py               — LangGraph graph, targeted_investigator, route_coordinator
 │   └── hitl.py                   — HITL approval/denial detection

--- a/v4/docs/capabilities.md
+++ b/v4/docs/capabilities.md
@@ -36,7 +36,7 @@ Metrics and logs are optional — without them, KubeIntellect still answers ever
 
 V4 also works *between* your questions:
 
-- **Zero-token known-failure detection** — the playbook library covers the 24 most common failures, and compiled detectors recognize 20 of them straight off the live cluster stream without spending a single LLM token. → [Agent Behaviors → V4 additions](agent-behaviors.md#v4-additions)
+- **Zero-token known-failure detection** — the playbook library covers the 25 most common failures, and compiled detectors recognize 20 of them straight off the live cluster stream without spending a single LLM token. → [Agent Behaviors → V4 additions](agent-behaviors.md#v4-additions)
 - **Self-opened investigations** — a firing detector opens its own investigation and publishes the report; how far it may go is set per namespace (A0–A3). → [Autonomous Operations](autonomy.md)
 - **Morning digest** — `kq digest` summarizes findings, autonomous investigations, and rollback points from the last N hours. → [Autonomous Operations → digest](autonomy.md#the-morning-digest)
 - **Tamper-evident audit replay** — every session is hash-chained in an append-only log; `kq replay <session-id>` reproduces it and verifies integrity. → [Flight Recorder & Replay](flight-recorder.md)
@@ -48,7 +48,7 @@ V4 also works *between* your questions:
 
 ## Failure patterns it recognizes
 
-KubeIntellect ships **24 built-in playbooks** — deterministic investigation
+KubeIntellect ships **25 built-in playbooks** — deterministic investigation
 recipes for the most common Kubernetes failures. When the cluster snapshot
 matches a pattern, the matching playbook guides the investigation automatically.
 You don't invoke these by name; they fire on their own.

--- a/v4/docs/examples.md
+++ b/v4/docs/examples.md
@@ -495,7 +495,7 @@ See [CLI Reference → `kq export`](cli-reference.md#kq-export-session-id).
 
 ## 14 · Teach it a new failure — `kq detector`
 
-Your cluster fails in a way the 24 shipped playbooks do not cover, and you want it recognised without writing Python.
+Your cluster fails in a way the 25 shipped playbooks do not cover, and you want it recognised without writing Python.
 
 **You run:**
 

--- a/v4/docs/faq.md
+++ b/v4/docs/faq.md
@@ -144,7 +144,7 @@ Plain ChatGPT can't see your cluster; KubeIntellect grounds every answer in live
 `kubectl` / Helm / Prometheus / Loki data. Beyond running commands, it adds
 capabilities those command-shaped tools don't combine: **parallel specialist
 subagents** (pod / metrics / logs / events) that fan out for a real root-cause
-analysis, **24 deterministic playbooks** that guide known-failure investigations,
+analysis, **25 deterministic playbooks** that guide known-failure investigations,
 a **human-in-the-loop approval gate** on every write, a **memory + reflexion**
 layer that recalls past incidents and promotes verified fixes, and an **autonomy**
 layer that opens its own investigations when a detector fires. See

--- a/v4/docs/glossary.md
+++ b/v4/docs/glossary.md
@@ -18,7 +18,7 @@ page where the concept is explained in depth.
 | **Memory loader** | The step that loads pinned, cross-session context (user prefs, past root causes, failure hints) into the prompt. Active only on PostgreSQL. |
 | **Cluster snapshot** | The pre-fetched picture of cluster health (pod list + Warning events) built at the start of every turn. Drives playbook matching and the snapshot sufficiency gate. |
 | **Snapshot sufficiency gate** | A soft bias that lets the agent answer healthy, list-shaped questions straight from the snapshot instead of re-querying. Modes: `off` / `lenient` / `strict`. See [Agent Behaviors](agent-behaviors.md#snapshot-sufficiency-gate). |
-| **Playbook** | A YAML investigation recipe for a known failure (CrashLoopBackOff, OOMKilled, …). When the snapshot matches, the playbook is injected into the prompt to guide the agent. 24 ship by default. See [Playbook library](agent-behaviors.md#playbook-library). |
+| **Playbook** | A YAML investigation recipe for a known failure (CrashLoopBackOff, OOMKilled, …). When the snapshot matches, the playbook is injected into the prompt to guide the agent. 25 ship by default. See [Playbook library](agent-behaviors.md#playbook-library). |
 | **Investigation plan** | A visible, up-front checklist the agent emits for queries needing 3+ steps, streamed as a `plan` event so the UI can show it. |
 | **RCA** | **Root-Cause Analysis** — the deep investigation path where four subagents run in parallel and the coordinator synthesizes their findings into one conclusion. |
 | **RCAResult** | The structured output of an RCA: root cause, confidence, supporting evidence, conflicting evidence, reasoning, and a recommended fix. See [What you can ask](capabilities.md#what-a-root-cause-answer-looks-like). |

--- a/v4/packages/kubeintellect-server/app/agent/playbooks/pdb_blocking.yaml
+++ b/v4/packages/kubeintellect-server/app/agent/playbooks/pdb_blocking.yaml
@@ -1,0 +1,40 @@
+name: PodDisruptionBudgetBlocking
+# An eviction refusal is an API response / drain stderr, not a guaranteed Warning
+# Event. Karpenter also reports PDB blockers as Normal events, which the current
+# snapshot/watch paths do not collect. Keep this triage-only, like NetworkPolicyBlocking;
+# these triggers match when the diagnostic text is supplied to the matcher.
+# Zero allowed disruptions alone is legitimate availability policy, not an incident.
+# Sources: https://kubernetes.io/docs/concepts/scheduling-eviction/api-eviction/
+#          https://karpenter.sh/docs/concepts/disruption/
+detect: null
+triggers:
+  - event_message_regex: "Cannot evict pod as it would violate the pod's disruption budget"
+  - event_message_regex: 'pdb .*prevents pod evictions'
+investigation_steps:
+  - "Confirm an intended drain/eviction is actually blocked: capture the operator's eviction refusal and the target pod, namespace and node. A PDB with zero allowed disruptions, or a Karpenter consolidation notice alone, does not prove an incident."
+  - "kubectl get pdb -n <ns> -o yaml — inspect selectors, minAvailable/maxUnavailable, unhealthyPodEvictionPolicy, currentHealthy, desiredHealthy, disruptionsAllowed, observedGeneration and conditions. If access is denied, report the missing evidence and request an authorized operator's output."
+  - "kubectl get pods -n <ns> --show-labels -o wide — match the target pod against every PDB selector in its namespace; include matchExpressions. In policy/v1 an empty selector matches all pods in that namespace."
+  - "kubectl describe pod <pod> -n <ns> — inspect Ready conditions, owner references, termination state and events. Unready or pending replacements may consume the budget."
+  - "kubectl get deployment,statefulset,replicaset -n <ns> — compare desired and ready replicas of the identified owner; investigate why replacement pods cannot become Ready before changing the PDB."
+  - "kubectl get events -n <ns> — correlate scheduling/readiness failures with the blocked workload. Do not rerun a mutating drain merely to obtain evidence."
+  - "Verify PDB status reflects the current generation and inspect DisruptionAllowed conditions. An HTTP 429 alone can also be throttling, and overlapping PDB selectors can cause a different eviction error; preserve the exact server response."
+expected_evidence:
+  - "A requested voluntary eviction is refused with a PDB-specific message, and the affected pod matches the named budget's selector"
+  - "Current PDB status and pod readiness explain the refusal; for a healthy pod, disruptionsAllowed is zero"
+  - "The workload owner and availability requirement are known; zero allowance may be intentional (for example a single replica with minAvailable: 1)"
+  - "If the error lacks a PDB cause, status is stale, or the pod matches no budget, do not conclude that a PDB change will fix the drain"
+recommended_fix_template: |
+  Eviction of <POD> in <NS> is blocked by <PDB>, confirmed by <REFUSAL>
+  and <CURRENT_STATUS>. The budget protects <AVAILABILITY_REQUIREMENT>.
+  Prefer restoring unhealthy replicas or, where the workload supports it,
+  adding capacity and waiting for additional Ready replicas before retrying.
+  A zero-budget single-replica workload may require an owner-approved maintenance
+  window; this is not automatically a misconfiguration.
+
+  If policy must change, obtain the workload owner's agreement on the availability
+  tradeoff. For an unhealthy Running pod, review unhealthyPodEvictionPolicy rather
+  than assuming healthy-pod eviction rules apply. Any scale, policy edit or drain
+  retry must use the existing dry-run/diff and human-approval gate. Do not delete
+  the PDB, directly delete pods, or use drain --disable-eviction to bypass protection.
+  After an approved change, recheck Ready replicas and current PDB status, then
+  confirm the intended eviction progresses while application availability holds.

--- a/v4/tests/test_every_playbook_is_reachable.py
+++ b/v4/tests/test_every_playbook_is_reachable.py
@@ -100,8 +100,8 @@ def test_every_playbook_has_a_trigger_that_could_fire(pb):
 
 def test_the_inventory_is_actually_covered():
     """Guard the guard: an empty registry would make both tests above pass vacuously."""
-    assert len(_PLAYBOOKS) == 24, f"playbook count changed to {len(_PLAYBOOKS)}"
-    assert len(_CASES) == 42, f"trigger-regex count changed to {len(_CASES)}"
+    assert len(_PLAYBOOKS) == 25, f"playbook count changed to {len(_PLAYBOOKS)}"
+    assert len(_CASES) == 44, f"trigger-regex count changed to {len(_CASES)}"
 
 
 def test_a_mistyped_trigger_key_is_exactly_the_shape_this_file_catches():

--- a/v4/tests/test_pdb_playbook.py
+++ b/v4/tests/test_pdb_playbook.py
@@ -1,0 +1,37 @@
+"""PDB refusal text routes to investigation, without inventing a watch signal."""
+from __future__ import annotations
+
+import pytest
+
+from app.agent.playbooks import get_playbook, match_playbooks
+
+
+@pytest.mark.parametrize("message", [
+    "Cannot evict pod as it would violate the pod's disruption budget.",
+    'Cannot disrupt Node: PDB "default/api" prevents pod evictions',
+    'pdb default/inflate-pdb prevents pod evictions',
+])
+def test_pdb_refusal_routes_to_playbook(message):
+    # Explicitly supplied diagnostic text; the normal snapshot only collects
+    # Warning events, not kubectl drain stderr or Karpenter's Normal events.
+    assert "PodDisruptionBudgetBlocking" in match_playbooks("", message)
+
+
+@pytest.mark.parametrize("message", [
+    "Cannot evict pod: Too Many Requests",
+    "The node was low on resource: memory",
+    "Cannot disrupt Node: state node is marked for deletion",
+    "DisruptionBlocked: do-not-disrupt annotation",
+    "NAME MIN AVAILABLE MAX UNAVAILABLE ALLOWED DISRUPTIONS AGE\napi 1 N/A 0 3d",
+    "",
+])
+def test_pdb_playbook_ignores_unrelated_or_insufficient_evidence(message):
+    assert "PodDisruptionBudgetBlocking" not in match_playbooks("", message)
+
+
+def test_pdb_playbook_is_available_without_a_fabricated_watch_detector():
+    playbook = get_playbook("PodDisruptionBudgetBlocking")
+    assert playbook is not None
+    assert playbook.detect is None
+    assert playbook.investigation_steps
+    assert playbook.expected_evidence

--- a/v4/tests/test_rbac_covers_the_playbooks.py
+++ b/v4/tests/test_rbac_covers_the_playbooks.py
@@ -60,6 +60,7 @@ _KINDS: dict[str, tuple[str, str]] = {
     "job": ("batch", "jobs"), "jobs": ("batch", "jobs"),
     "cronjob": ("batch", "cronjobs"),
     "hpa": ("autoscaling", "horizontalpodautoscalers"),
+    "pdb": ("policy", "poddisruptionbudgets"),
     "horizontalpodautoscaler": ("autoscaling", "horizontalpodautoscalers"),
     "networkpolicy": ("networking.k8s.io", "networkpolicies"),
     "netpol": ("networking.k8s.io", "networkpolicies"),


### PR DESCRIPTION
## What & why

Related to #13; claimed the PDB topic in https://github.com/MSKazemi/kubeintellect/issues/13#issuecomment-5596045861. Leaves the umbrella issue open.

Add `PodDisruptionBudgetBlocking`, a triage guide for a voluntary eviction refused by a PDB. It requires a specific refusal plus current selector, budget and readiness evidence before recommending action. Zero allowed disruptions alone is not treated as a fault. Prefer restoring availability; policy changes and drain retries retain human approval.

The playbook deliberately uses `detect: null`: drain stderr is not a Kubernetes Warning Event, and Karpenter's PDB notices can be Normal events. Text routing recognizes those messages when supplied to the matcher, but the default Warning-only snapshot does not ingest them. This adds the guide and matching rules, not a new automatic drain detector or input channel. That limitation is documented.

Read-only PDB permissions are added to both shipped roles so the investigation can retrieve its required evidence. The RBAC coverage test maps the new resource. Generated documentation counts and inventory guards are updated.

## Type of change

- [x] New feature
- [x] Docs
- [x] Tests

## Scope

- v4 playbook, tests, chart read permissions, and generated documentation counts (including root AGENTS/CONTRIBUTING/ROADMAP).
- [x] Scoped to the current version.

## Checklist and validation

- [x] Positive and negative routing tests; four positive/registration cases failed before the playbook existed.
- [x] Triage-only detection explicitly tested as absent; no fabricated Event reason or zero-budget alert.
- [x] No cluster mutations added; human approval and secret handling preserved.
- [x] Ruff passes over the exact CONTRIBUTING/AGENTS scope.
- [x] Linux-targeted mypy passes: 193 source files. Native Windows mypy reports the existing `os.geteuid` reference.
- [x] Final focused tests pass on Python 3.12 and 3.13: **154 each**, including playbooks, routing, rendered Helm RBAC, documentation counts, and the rollback tests from newly merged upstream #195.
- [x] File modes (957 indexed files), syntax/encoding (565 Python files before upstream #195), roster and documentation-count gates passed. MkDocs built with existing missing-link warnings.
- [ ] Full suites green locally: **not claimed**. On Windows, both interpreters initially returned 82 server failures, 6 errors, 5339 passes and 106 skips. The unchanged base reproduced 80 failures and all 6 errors with identical names; the two additional failures were documentation counts, subsequently fixed and passing in the final focused runs. The CLI suite returned 10 failures / 739 passes; unchanged base reproduced all ten. Examples include Unix file-mode assumptions, shell execution and Windows SQLite file locking.

## Notes for reviewers

No live cluster was used. Helm 4.2.4 rendered the actual chart for the RBAC tests. Upstream #195 was merged and counts regenerated before final validation.

References: [Kubernetes eviction API](https://kubernetes.io/docs/concepts/scheduling-eviction/api-eviction/), [PDB configuration](https://kubernetes.io/docs/tasks/run-application/configure-pdb/), [Karpenter disruption messages](https://karpenter.sh/docs/concepts/disruption/).

Prepared and validated with OpenAI Codex under the account owner's direction; substantial AI assistance is disclosed.
