### PR TITLE
docs(playbooks): say that co-firing is normal, and pin it with a test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ uv run ruff check packages/kubeintellect-server/app/ packages/ki-protocol/ packa
 # 2. Types — the workspace is at ZERO errors; keep it there.
 uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube-q/kube_q
 
-# 3. Server suite (5542 tests)
+# 3. Server suite (5545 tests)
 uv run python -m pytest tests/ -q
 
 # 4. kq CLI suite (749 tests)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube
 
 # 3. Tests — two suites, run separately: the two `tests` packages collide
 #    under a single pytest invocation.
-uv run python -m pytest tests/ -q                              # server (~5542 tests)
+uv run python -m pytest tests/ -q                              # server (~5545 tests)
 cd packages/kube-q && uv run python -m pytest tests/ -q        # kq CLI (~749 tests)
 ```
 

--- a/v4/docs/agent-behaviors.md
+++ b/v4/docs/agent-behaviors.md
@@ -292,6 +292,23 @@ A playbook matches if any of its triggers matches. The coordinator still has
 agency — it can deviate when the situation warrants — but the playbook gives it
 a strong default.
 
+**`match_playbooks` returns candidates, not a verdict, and several matching at once
+is normal.** Some shipped triggers are deliberately broad — `imagepullbackoff.yaml`
+and `createcontainerconfigerror.yaml` both carry `event_reason_regex: "Failed"` — so
+an ordinary two-line events stream showing a failed image pull and a restart back-off
+routes to `CrashLoopBackOff`, `CreateContainerConfigError`, `ImagePullBackOff` **and**
+`InitContainerFailing` together. That is the router working: it is cheaper to offer
+the coordinator one candidate too many than to stay silent on the right one.
+
+The consequence for anyone **writing** a playbook is that "mine will co-fire with
+existing ones" is not a reason to withhold it. The bar is different, and narrower:
+
+* it must not fire when **nothing is wrong** — see `pdb_blocking.yaml`, where a
+  `disruptionsAllowed: 0` budget is legitimate availability policy rather than an
+  incident, with a negative test pinning that;
+* it must not be the *only* thing pointing at a **different** failure, which is what
+  the cross-fire tests in `tests/test_playbooks.py` exist to check.
+
 **Disable:** `PLAYBOOKS_ENABLED=false`.
 
 ---

--- a/v4/tests/test_playbook_routing_offers_candidates_not_a_verdict.py
+++ b/v4/tests/test_playbook_routing_offers_candidates_not_a_verdict.py
@@ -1,0 +1,52 @@
+"""`match_playbooks` returns candidates, and several matching at once is normal.
+
+`docs/agent-behaviors.md` tells playbook authors that co-firing with existing playbooks is
+not a reason to withhold a new one, and names the exact example below. That is a behavioural
+claim about the router, so it is pinned here rather than left to rot in prose -- a contributor
+assessing whether their playbook is "too generic to add" reads that paragraph and acts on it.
+
+The bar a new playbook has to clear is narrower than "matches alone": it must not fire when
+nothing is wrong, and it must not be the only thing pointing at a different failure.
+"""
+from __future__ import annotations
+
+from app.agent.playbooks import match_playbooks
+
+# An ordinary events stream: one failed image pull, one restart back-off.
+_EVENTS = (
+    "NAMESPACE LAST SEEN TYPE REASON OBJECT MESSAGE\n"
+    'shop 2m Warning Failed pod/api-1 Failed to pull image "x": not found\n'
+    "shop 1m Warning BackOff pod/api-1 Back-off restarting failed container\n"
+)
+
+
+def test_one_ordinary_events_stream_routes_to_several_playbooks():
+    """If this ever returns one name, the docs paragraph above is wrong."""
+    matched = set(match_playbooks("", _EVENTS))
+    assert {
+        "CrashLoopBackOff",
+        "CreateContainerConfigError",
+        "ImagePullBackOff",
+        "InitContainerFailing",
+    } <= matched, (
+        "docs/agent-behaviors.md names these four as co-firing on this stream; "
+        f"got {sorted(matched)}"
+    )
+
+
+def test_the_broad_failed_reason_triggers_are_still_broad():
+    """The two deliberately-broad triggers the docs cite by name."""
+    only_failed = (
+        "NAMESPACE LAST SEEN TYPE REASON OBJECT MESSAGE\n"
+        "shop 2m Warning Failed pod/api-1 something went wrong\n"
+    )
+    matched = set(match_playbooks("", only_failed))
+    assert {"ImagePullBackOff", "CreateContainerConfigError"} <= matched, (
+        "both carry event_reason_regex: 'Failed'; if that is narrowed, the docs "
+        f"paragraph explaining why co-firing is normal needs rewriting. got {sorted(matched)}"
+    )
+
+
+def test_an_empty_snapshot_routes_nowhere():
+    """Guard the guard: matching everything would make the assertions above vacuous."""
+    assert match_playbooks("", "") == []


### PR DESCRIPTION
`docs/agent-behaviors.md` said *"a playbook matches if any of its triggers matches"* and stopped there. It never said that **several playbooks routinely match one snapshot**, and that this is the router working rather than a defect.

## That omission has a measurable cost

@biggdawg320 paused before claiming the StatefulSet playbook on #13 specifically because *"generic Pending/Unhealthy messages already select existing playbooks"*. A correct observation — and a reasonable thing to read as disqualifying. It is not: `match_playbooks` returns **candidates for the coordinator to choose from**, not a classification.

## Measured, and now stated

`imagepullbackoff.yaml` and `createcontainerconfigerror.yaml` both carry `event_reason_regex: "Failed"`, so an ordinary two-line events stream:

```
Warning  Failed   pod/api-1  Failed to pull image "x": not found
Warning  BackOff  pod/api-1  Back-off restarting failed container
```
```
routes to: CrashLoopBackOff, CreateContainerConfigError,
           ImagePullBackOff, InitContainerFailing
```

The paragraph also states the bar that **actually** applies to a new playbook, which is narrower than "matches alone":

- it must not fire when **nothing is wrong** — `pdb_blocking.yaml` and its `disruptionsAllowed: 0` negative test are the worked example;
- it must not be the *only* thing pointing at a **different** failure.

## Pinned, not just written

Three tests, because this is a behavioural claim that would otherwise rot: the four co-firing names, the two broad `Failed` triggers the paragraph cites by name, and an empty snapshot routing nowhere — the last so the first two cannot pass vacuously by matching everything.

Gates: `ruff` clean · doc claims recollected to **5545** · full server suite **5522 passed / 23 skipped** · `mkdocs build` clean.