### PR TITLE
feat(playbooks): add StatefulSet rollout triage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ uv run ruff check packages/kubeintellect-server/app/ packages/ki-protocol/ packa
 # 2. Types — the workspace is at ZERO errors; keep it there.
 uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube-q/kube_q
 
-# 3. Server suite (5545 tests)
+# 3. Server suite (5562 tests)
 uv run python -m pytest tests/ -q
 
 # 4. kq CLI suite (749 tests)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube
 
 # 3. Tests — two suites, run separately: the two `tests` packages collide
 #    under a single pytest invocation.
-uv run python -m pytest tests/ -q                              # server (~5545 tests)
+uv run python -m pytest tests/ -q                              # server (~5562 tests)
 cd packages/kube-q && uv run python -m pytest tests/ -q        # kq CLI (~749 tests)
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,7 @@ The `v4/` platform is the current line and the only one you should deploy.
 - Conversational diagnosis correlating **kubectl + Prometheus + Loki**.
 - **Human-in-the-loop approval gate** with RBAC (superadmin / admin / operator / readonly) on
   every mutating action, enforced server-side at the mutating chokepoint.
-- **25 declarative failure playbooks** (`detect → investigate → remediate`), 20 of which compile
+- **26 declarative failure playbooks** (`detect → investigate → remediate`), 20 of which compile
   to zero-token detectors.
 - **Zero-token detection** — a detector engine over a kubectl `--watch` sensorium fires
   findings without invoking the LLM.
@@ -51,7 +51,7 @@ These are concrete, scoped, and mostly open to contribution.
 | **Composable detectors** — AND / NOT / temporal windows | Open | [#21](https://github.com/MSKazemi/kubeintellect/issues/21) ✅ |
 | **PromQL execution in playbook `detect` blocks** | Open | [#20](https://github.com/MSKazemi/kubeintellect/issues/20) ✅ |
 | **Temporal KG ingesting nodes / events / PVCs** | Open | [#19](https://github.com/MSKazemi/kubeintellect/issues/19) ✅ |
-| Grow the **playbook library** beyond 25 | Ongoing — a playbook is one YAML file; 18 → 23 in Aug 2026 via [#108](https://github.com/MSKazemi/kubeintellect/pull/108), [#112](https://github.com/MSKazemi/kubeintellect/pull/112), [#114](https://github.com/MSKazemi/kubeintellect/pull/114), [#127](https://github.com/MSKazemi/kubeintellect/pull/127) and [#128](https://github.com/MSKazemi/kubeintellect/pull/128) | [#13](https://github.com/MSKazemi/kubeintellect/issues/13) ✅ |
+| Grow the **playbook library** beyond 26 | Ongoing — a playbook is one YAML file; 18 → 23 in Aug 2026 via [#108](https://github.com/MSKazemi/kubeintellect/pull/108), [#112](https://github.com/MSKazemi/kubeintellect/pull/112), [#114](https://github.com/MSKazemi/kubeintellect/pull/114), [#127](https://github.com/MSKazemi/kubeintellect/pull/127) and [#128](https://github.com/MSKazemi/kubeintellect/pull/128) | [#13](https://github.com/MSKazemi/kubeintellect/issues/13) ✅ |
 
 ## Housekeeping — known debt, stated plainly
 

--- a/v4/docs/agent-behaviors.md
+++ b/v4/docs/agent-behaviors.md
@@ -236,7 +236,7 @@ detects a matching pattern in the snapshot, the coordinator's system prompt
 includes the playbook(s) inline — guiding it to follow proven steps before
 improvising.
 
-**Playbooks shipped (25):**
+**Playbooks shipped (26):**
 
 *Pod / container lifecycle*
 
@@ -562,6 +562,15 @@ triggers:
 - `detect: null` marks a playbook as **LLM-only** (no machine signal exists,
   or the signal is owned by another playbook).
 
+`StatefulSetRolloutStuck` is a triage-only guide for investigating an ordinal
+that is not progressing. Its narrow controller Pod/Claim creation-error triggers
+offer a candidate, not a stalled-rollout verdict. It has `detect: null`: ordinary
+Pending or unready pods cannot distinguish normal waiting from a stall. For PVC
+or readiness stalls without creation errors, use the guide during investigation
+after establishing StatefulSet ownership and comparing progress over time; this
+change does not add automatic routing for those cases. Check intentional
+partitions, OnDelete strategy and minReadySeconds before recommending a change.
+
 `PodDisruptionBudgetBlocking` is a triage-only guide for a confirmed blocked
 voluntary eviction. Its text triggers recognize a PDB-specific eviction refusal
 or Karpenter's PDB blocker message when supplied to the matcher. The default
@@ -694,7 +703,7 @@ change; zero allowed disruptions by itself can be intentional availability polic
     threshold on the first scrape. That depends on runtime values, so it belongs to a
     shadow period and a human, not to a validator.
 
-Of the 25 shipped playbooks, **20 compile to detectors**; 4 are LLM-only
+Of the 26 shipped playbooks, **20 compile to detectors**; 4 are LLM-only
 (`CommandHardcodedFailure` — disambiguated from CrashLoopBackOff only by
 reading the pod spec — `ServiceUnreachable`, `NetworkPolicyBlocking`,
 where the packet is discarded in the CNI datapath so no machine signal

--- a/v4/docs/architecture.md
+++ b/v4/docs/architecture.md
@@ -487,7 +487,7 @@ packages/
 │   │   ├── coordinator.py        — LLM decision + synthesis, tool trimmer, reflexion writes
 │   │   ├── memory_loader.py      — load pinned cluster context + failure-pattern hints
 │   │   └── subagent.py           — 4 specialist subagent runners
-│   ├── playbooks/                — YAML playbook library + loader (25 playbooks)
+│   ├── playbooks/                — YAML playbook library + loader (26 playbooks)
 │   ├── state.py                  — AgentState, SubagentInput, AgentFinding, RCAResult
 │   ├── workflow.py               — LangGraph graph, targeted_investigator, route_coordinator
 │   └── hitl.py                   — HITL approval/denial detection

--- a/v4/docs/capabilities.md
+++ b/v4/docs/capabilities.md
@@ -36,7 +36,7 @@ Metrics and logs are optional — without them, KubeIntellect still answers ever
 
 V4 also works *between* your questions:
 
-- **Zero-token known-failure detection** — the playbook library covers the 25 most common failures, and compiled detectors recognize 20 of them straight off the live cluster stream without spending a single LLM token. → [Agent Behaviors → V4 additions](agent-behaviors.md#v4-additions)
+- **Zero-token known-failure detection** — the playbook library covers the 26 most common failures, and compiled detectors recognize 20 of them straight off the live cluster stream without spending a single LLM token. → [Agent Behaviors → V4 additions](agent-behaviors.md#v4-additions)
 - **Self-opened investigations** — a firing detector opens its own investigation and publishes the report; how far it may go is set per namespace (A0–A3). → [Autonomous Operations](autonomy.md)
 - **Morning digest** — `kq digest` summarizes findings, autonomous investigations, and rollback points from the last N hours. → [Autonomous Operations → digest](autonomy.md#the-morning-digest)
 - **Tamper-evident audit replay** — every session is hash-chained in an append-only log; `kq replay <session-id>` reproduces it and verifies integrity. → [Flight Recorder & Replay](flight-recorder.md)
@@ -48,7 +48,7 @@ V4 also works *between* your questions:
 
 ## Failure patterns it recognizes
 
-KubeIntellect ships **25 built-in playbooks** — deterministic investigation
+KubeIntellect ships **26 built-in playbooks** — deterministic investigation
 recipes for the most common Kubernetes failures. When the cluster snapshot
 matches a pattern, the matching playbook guides the investigation automatically.
 You don't invoke these by name; they fire on their own.

--- a/v4/docs/examples.md
+++ b/v4/docs/examples.md
@@ -495,7 +495,7 @@ See [CLI Reference → `kq export`](cli-reference.md#kq-export-session-id).
 
 ## 14 · Teach it a new failure — `kq detector`
 
-Your cluster fails in a way the 25 shipped playbooks do not cover, and you want it recognised without writing Python.
+Your cluster fails in a way the 26 shipped playbooks do not cover, and you want it recognised without writing Python.
 
 **You run:**
 

--- a/v4/docs/faq.md
+++ b/v4/docs/faq.md
@@ -144,7 +144,7 @@ Plain ChatGPT can't see your cluster; KubeIntellect grounds every answer in live
 `kubectl` / Helm / Prometheus / Loki data. Beyond running commands, it adds
 capabilities those command-shaped tools don't combine: **parallel specialist
 subagents** (pod / metrics / logs / events) that fan out for a real root-cause
-analysis, **25 deterministic playbooks** that guide known-failure investigations,
+analysis, **26 deterministic playbooks** that guide known-failure investigations,
 a **human-in-the-loop approval gate** on every write, a **memory + reflexion**
 layer that recalls past incidents and promotes verified fixes, and an **autonomy**
 layer that opens its own investigations when a detector fires. See

--- a/v4/docs/glossary.md
+++ b/v4/docs/glossary.md
@@ -18,7 +18,7 @@ page where the concept is explained in depth.
 | **Memory loader** | The step that loads pinned, cross-session context (user prefs, past root causes, failure hints) into the prompt. Active only on PostgreSQL. |
 | **Cluster snapshot** | The pre-fetched picture of cluster health (pod list + Warning events) built at the start of every turn. Drives playbook matching and the snapshot sufficiency gate. |
 | **Snapshot sufficiency gate** | A soft bias that lets the agent answer healthy, list-shaped questions straight from the snapshot instead of re-querying. Modes: `off` / `lenient` / `strict`. See [Agent Behaviors](agent-behaviors.md#snapshot-sufficiency-gate). |
-| **Playbook** | A YAML investigation recipe for a known failure (CrashLoopBackOff, OOMKilled, …). When the snapshot matches, the playbook is injected into the prompt to guide the agent. 25 ship by default. See [Playbook library](agent-behaviors.md#playbook-library). |
+| **Playbook** | A YAML investigation recipe for a known failure (CrashLoopBackOff, OOMKilled, …). When the snapshot matches, the playbook is injected into the prompt to guide the agent. 26 ship by default. See [Playbook library](agent-behaviors.md#playbook-library). |
 | **Investigation plan** | A visible, up-front checklist the agent emits for queries needing 3+ steps, streamed as a `plan` event so the UI can show it. |
 | **RCA** | **Root-Cause Analysis** — the deep investigation path where four subagents run in parallel and the coordinator synthesizes their findings into one conclusion. |
 | **RCAResult** | The structured output of an RCA: root cause, confidence, supporting evidence, conflicting evidence, reasoning, and a recommended fix. See [What you can ask](capabilities.md#what-a-root-cause-answer-looks-like). |

--- a/v4/packages/kubeintellect-server/app/agent/playbooks/statefulset_rollout_stuck.yaml
+++ b/v4/packages/kubeintellect-server/app/agent/playbooks/statefulset_rollout_stuck.yaml
@@ -1,0 +1,47 @@
+name: StatefulSetRolloutStuck
+# Triage-only: neither a Pending pod nor a readiness failure distinguishes a normal
+# rollout wait from stalled progress. WatchPredicate cannot correlate ownership,
+# revisions and progress across observations. Do not invent a StatefulSet Event
+# from kubectl rollout status stdout. The controller creation failures below are
+# real candidate-selection signals, not proof that a rollout is stuck.
+# Sources: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+#          kubernetes/pkg/controller/statefulset/stateful_pod_control.go
+detect: null
+triggers:
+  - event_message_regex: 'create Pod [a-z0-9.-]+ in StatefulSet [a-z0-9.-]+ failed error:'
+  - event_message_regex: 'create Claim [a-z0-9.-]+ for Pod [a-z0-9.-]+ in StatefulSet [a-z0-9.-]+ failed error:'
+investigation_steps:
+  - "Confirm the intended update with the workload owner. Record namespace, StatefulSet, desired revision and when progress stopped; a creation failure can also occur during initial deployment or scaling, not just a rollout."
+  - "kubectl get statefulset <sts> -n <ns> -o yaml — inspect generation/observedGeneration, replicas, currentRevision/updateRevision, updatedReplicas, readyReplicas, updateStrategy (including rollingUpdate.partition), podManagementPolicy, minReadySeconds and ordinals.start. An OnDelete strategy or a deliberate partition is not automatically a stalled rollout."
+  - "kubectl get pods -n <ns> -o wide — identify candidate ordinals, then kubectl get pod <pod> -n <ns> -o yaml to confirm ownerReferences UID against the StatefulSet, controller-revision-hash, volume claim names, deletionTimestamp and Ready conditions. Do not infer ownership from a name prefix or assume ordinals start at zero."
+  - "Compare at least two timestamped observations of the intended update. Check which ordinal has not advanced to the intended revision or become Ready beyond the workload's expected startup interval, including minReadySeconds. Ordered creation waits on lower ordinals, whereas rolling updates normally advance from higher ordinals; inspect the configured strategy before assuming which pod blocks the next one."
+  - "kubectl describe pod <pod> -n <ns> — inspect scheduling, mounts, container states, readiness probes and spec.readinessGates with matching status.conditions. A Running phase does not imply Ready; distinguish a failing container probe from an unmet custom readiness gate."
+  - "kubectl get pvc <claim> -n <ns> -o yaml and kubectl describe pvc <claim> -n <ns> — use the pod's actual claim reference to inspect phase, storageClassName, volumeName and provisioning events. Pending may be normal while waiting for a consumer; correlate scheduling and repeated failures before diagnosing storage. Use PvcPending or the relevant scheduling playbook for the underlying cause."
+  - "kubectl get events -n <ns> --sort-by=.lastTimestamp — correlate the named StatefulSet's creation error and its pods/PVCs. Use ReadinessProbeFailing, ImagePullBackOff or QuotaExceeded when those explain the blocking ordinal; multiple candidate playbooks are expected. If access is denied or observations are missing, state the evidence gap rather than asserting a stall."
+expected_evidence:
+  - "A known intended update and a verified StatefulSet owner; repeated observations show no expected revision/readiness progress beyond the agreed startup interval"
+  - "The blocking ordinal and specific PVC, scheduling, container or readiness-gate evidence; creation errors alone do not prove a stalled update"
+  - "OnDelete behavior, an intentional partition, minReadySeconds and normal ordered waiting have been checked before calling the rollout stuck"
+recommended_fix_template: |
+  StatefulSet <STS> in <NS> is blocked at ordinal <ORDINAL>, supported by
+  <TIMESTAMPED_PROGRESS_COMPARISON> and <PVC_OR_READINESS_OR_CREATION_EVIDENCE>.
+  If that evidence is incomplete, gather it before recommending a mutation.
+
+  Address the measured cause: repair the provisioning/scheduling constraint,
+  correct the rejected pod specification, or restore the dependency/probe/gate
+  controller that prevents readiness. Respect the workload's quorum and storage
+  requirements. Do not delete PVCs, disable readiness gates, force-delete pods,
+  or change ordering/partition merely to make the rollout appear complete.
+
+  For a bad template, propose reverting it with the workload owner. StatefulSet
+  rollback can still wait for a broken pod after the template is reverted;
+  reverting alone is not a guarantee of recovery. If recreation is necessary,
+  review the exact affected pod and data/quorum consequences with an authorized
+  operator before any normally graceful deletion. Never force it or automate it
+  from this guide. All manifest, scale, partition, rollback or pod changes retain
+  the existing dry-run/diff and explicit human-approval gate.
+
+  After approved remediation, verify the intended ordinals reach their expected
+  revision and remain Ready for minReadySeconds, PVCs retain their data, and
+  application health/quorum holds. A partitioned update may intentionally leave
+  older ordinals at their previous revision; do not demand equality everywhere.

--- a/v4/tests/test_every_playbook_is_reachable.py
+++ b/v4/tests/test_every_playbook_is_reachable.py
@@ -115,10 +115,10 @@ _BUMP_HINT = (
 
 def test_the_inventory_is_actually_covered():
     """Guard the guard: an empty registry would make both tests above pass vacuously."""
-    assert len(_PLAYBOOKS) == 25, (
+    assert len(_PLAYBOOKS) == 26, (
         f"playbook count changed to {len(_PLAYBOOKS)}{_BUMP_HINT}"
     )
-    assert len(_CASES) == 44, (
+    assert len(_CASES) == 46, (
         f"trigger-regex count changed to {len(_CASES)}{_BUMP_HINT}"
     )
 

--- a/v4/tests/test_statefulset_playbook.py
+++ b/v4/tests/test_statefulset_playbook.py
@@ -1,0 +1,41 @@
+"""Controller creation failures offer triage; normal rollout waits do not."""
+from __future__ import annotations
+
+import pytest
+
+from app.agent.playbooks import get_playbook, match_playbooks
+
+
+@pytest.mark.parametrize("message", [
+    'Create Pod web-0 in StatefulSet web failed error: pods "web-0" is forbidden',
+    'Create Claim data-web-0 for Pod web-0 in StatefulSet web failed error: exceeded quota',
+])
+def test_statefulset_creation_failure_offers_triage(message):
+    # Controller FailedCreate event forms, not fabricated rollout-status events.
+    events = f"1m Warning FailedCreate statefulset/web {message}\n"
+    assert "StatefulSetRolloutStuck" in match_playbooks("", events)
+
+
+@pytest.mark.parametrize("pods,events", [
+    ("", ""),
+    ("web-0 0/1 Pending 0 10s", ""),
+    ("web-0 0/1 Running 0 10s", ""),
+    ("", "Waiting for 1 pods to be ready..."),
+    ("", "Waiting for partitioned roll out to finish: 1 out of 2 new pods have been updated..."),
+    ("", "statefulset rolling update complete 3 pods at revision web-abc..."),
+    ("", "Normal SuccessfulCreate statefulset/web create Pod web-0 in StatefulSet web successful"),
+    ("", "Warning Unhealthy pod/web-0 Readiness probe failed: HTTP probe failed with statuscode: 503"),
+    ("", "Warning FailedScheduling pod/web-0 pod has unbound immediate PersistentVolumeClaims"),
+    ("", 'Warning FailedCreate replicaset/api Error creating: pods "api-123" is forbidden'),
+    ("", 'Warning FailedCreate statefulset/web create Pod web-0 in StatefulSet web successful\nWarning Failed pod/api failed error: image missing'),
+])
+def test_statefulset_triage_does_not_infer_stall_from_insufficient_evidence(pods, events):
+    assert "StatefulSetRolloutStuck" not in match_playbooks(pods, events)
+
+
+def test_statefulset_guide_loads_without_claiming_automatic_stall_detection():
+    playbook = get_playbook("StatefulSetRolloutStuck")
+    assert playbook is not None
+    assert playbook.detect is None
+    assert playbook.investigation_steps
+    assert playbook.expected_evidence


### PR DESCRIPTION
## What & why

Adds StatefulSetRolloutStuck as a triage-only guide for a blocked ordinal, following the scope agreed in #13 (comment 5597827582). Controller Pod/Claim creation failures now offer it as a candidate. The guide requires verified ownership and timestamped progress evidence, and checks PVC/readiness causes, OnDelete, intentional partitions and minReadySeconds before diagnosing a stall.

Related to #13; leaves the umbrella issue and TLS topic open. Claim: https://github.com/MSKazemi/kubeintellect/issues/13#issuecomment-5598000194

## Type of change

- [x] ✨ New playbook
- [x] 📖 Docs
- [x] 🧪 Tests

## Scope

- v4 playbook, 14 focused tests, manual inventory assertions (26 playbooks / 46 trigger regexes), and generated count updates. Root AGENTS/CONTRIBUTING/ROADMAP changes are generated counts only.
- Based on main 77816be, including #200 and #201.
- No new permissions, telemetry collection or automatic stall detector. Existing rendered chart permissions cover the read commands.

## Checklist and validation

- [x] Before adding YAML: 3 failed / 11 passed in the new test file. After: all 14 pass.
- [x] Python 3.12 and 3.13: 165 focused tests pass each (routing, playbooks, doc claims, rendered Helm RBAC).
- [x] Exact CI lint scope passes; Linux-targeted mypy passes, 193 files.
- [x] Doc claims match; MkDocs builds with existing missing-link/page warnings.
- [x] File-mode gate: 961 files; syntax/encoding gates: 568 Python files; roster: 11 contributors; published diff whitespace check passes. File-mode script used an LF-normalized copy under Git Bash.
- [ ] Full application suites green locally — **not claimed**. Both Python versions on Windows: server **80 failed / 5384 passed / 92 skipped / 6 errors**; CLI **10 failed / 739 passed**. Every failure/error node ID matches our previously recorded unchanged Windows baseline, with no new failure names. This is comparison against that prior baseline run, not a new baseline run on this revision. Upstream Linux CI remains the full-suite check.
- [x] Human approval, dry-run/diff, quorum and persistent-data safeguards retained. No cluster or LLM calls used in validation.

## Notes for reviewers

`detect: null` is intentional. A snapshot cannot establish elapsed rollout progress or correlate ownership through WatchPredicate. Generic Pending/Unhealthy and normal rollout-status output do not match this guide. PVC/readiness stalls without a creation error remain investigation cases; this PR does not add automatic routing for them. Multiple candidate playbooks may co-fire, per #201.

Tests cover real controller creation-message forms, success, ordinary waiting, unrelated ReplicaSet/readiness/scheduling errors, empty input and a multi-line negative to prevent combining a success with another object's failure. Message templates were checked against Kubernetes stateful_pod_control.go. Recovery guidance explicitly notes that reverting a bad template alone may not recover a StatefulSet, while preserving approval before any affected-pod recreation.

Substantial Codex assistance was used to research, implement and run validation.
