### PR TITLE
docs(adopters): the list is no longer empty, and the banner said it was

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -7,9 +7,12 @@ platform team asks before adopting a young project — and because knowing *how*
 people run it is what tells the maintainers which parts to harden next. Adding
 yourself is the single lowest-effort, highest-value contribution to the project.
 
-> **Status: none listed yet.** KubeIntellect went public recently, so this list is
-> honestly empty rather than padded. If you're running it — even a Kind cluster on
-> a laptop — you would be the first entry.
+> **Status: one entry.** [@ybayraktarb](https://github.com/ybayraktarb) was the
+> first, in August 2026 — a k3s/k3d cluster on macOS, and the run that found the
+> README quickstart had never worked ([#151](https://github.com/MSKazemi/kubeintellect/pull/151)).
+> One is a small number and this list stays honest about that rather than padded.
+> If you're running KubeIntellect — even a Kind cluster on a laptop — you would be
+> the second entry, and "evaluating it" is a perfectly good row.
 
 ## The list
 


### PR DESCRIPTION
## What

`ADOPTERS.md` opened with a banner reading **"Status: none listed yet."** It has been wrong since 2026-08-21, when [@ybayraktarb](https://github.com/ybayraktarb)'s row landed in #151.

## Why it matters more than a stale sentence usually would

The banner sits *directly above the table*. So a reader arriving at the page saw the project assert that nobody is listed, with a row naming somebody one line below it. Two consequences:

1. **It erased the credit the table exists to give.** Being the first adopter is the whole point of being the first adopter, and the page said there wasn't one.
2. **It is the page a platform team reads** when asking "is anyone actually running this?" — the question `ADOPTERS.md` was created to answer honestly. Answering it with a self-contradiction is worse than either answer alone.

## What it says now

One entry, who it is, when, and what that run actually found — the k3s/k3d verification that surfaced that the README quickstart had never worked. It keeps the same invitation, now addressed to whoever would be *second*, and it stays explicit that one is a small number rather than implying a crowd.

The two `CHANGELOG.md` occurrences of "honestly empty" are left alone deliberately — they are historical entries and were accurate when written.

## Gates run

```
roster OK — .all-contributorsrc and the README table name the same 11 contributors
file modes OK — 961 file(s) ... executable if and only if they have a shebang
syntax OK — 568 tracked Python files outside v1-v3 compile with no SyntaxWarning
encoding OK — 568 tracked Python files outside v1-v3 name an encoding
```

Docs-only; no Python touched, and `check_doc_claims.py` does not read `ADOPTERS.md`.