### PR TITLE
docs: stop calling this a one-author project on the pages that invite contributors

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -35,10 +35,10 @@ New maintainers are invited by existing maintainers based on a sustained track r
 high-quality contributions and good community judgment.
 
 ### Lead maintainer / BDFL (for now)
-KubeIntellect was created by **Mohsen Seyedkazemi Ardebili** and is currently led by the author,
-who also holds the copyright that makes the dual-license model possible (see below). The lead
-maintainer has final say on direction and on decisions where consensus can't be reached — a role
-we intend to dilute into a maintainer group as the project matures.
+KubeIntellect was created by **Mohsen Seyedkazemi Ardebili**, who currently leads it and holds
+the copyright that makes the dual-license model possible (see below). The lead maintainer has
+final say on direction and on decisions where consensus can't be reached — a role we intend to
+dilute into a maintainer group as the project matures.
 
 ### Stepping back, and what happens if the lead maintainer disappears
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,9 @@ expected, it is not your mistake, and you do not need to do anything.
 
 ## Maintainer
 
-KubeIntellect is created, led, and maintained by **[Mohsen Seyedkazemi Ardebili](https://github.com/MSKazemi)** — see [GOVERNANCE.md](GOVERNANCE.md).
+KubeIntellect was created by **[Mohsen Seyedkazemi Ardebili](https://github.com/MSKazemi)**, who
+maintains it today — see [GOVERNANCE.md](GOVERNANCE.md). The shipped code is the work of the
+people named below as well, and that list is meant to grow.
 
 Where the project is going — and what it deliberately **won't** do — is in **[ROADMAP.md](ROADMAP.md)**. It has one maintainer today; the contributor ladder in [GOVERNANCE.md](GOVERNANCE.md) is a real invitation, not a formality, and areas are genuinely available to own.
 
@@ -306,7 +308,10 @@ thing the project cannot get any other way.
 > graph too, the one-line docs PR that comes out of what you found will do it — and is usually
 > warranted anyway. See [GOVERNANCE.md](GOVERNANCE.md) for the full ladder.
 
-## Other projects by the same author
+## Also from the maintainer
+
+Two other open-source projects, both of which welcome contributors on exactly the same terms as
+this one — and if you have contributed here, you already know how they are run.
 
 - **[YazSes](https://github.com/MSKazemi/yazses)** — offline voice dictation for Linux, macOS
   and Windows. Hold a key, speak, release; speech-to-text runs on your own CPU and nothing is


### PR DESCRIPTION
## The problem

Three places described KubeIntellect as the work of a single author. Two sections above one of them, the contributor table now names **fourteen people** and states that a merged commit is not the entry fee.

Both cannot be the project's position, and the authorship phrasing is the one that undercuts everything around it.

## The worst offender

```
## Other projects by the same author
```

"The same author" asserts sole authorship of *this* repo purely in order to introduce two others. It is the **last heading a visitor reads before the licence** — immediately after a table of contributors — so it lands as a quiet correction of that table.

It is now:

```
## Also from the maintainer

Two other open-source projects, both of which welcome contributors on exactly the same
terms as this one — and if you have contributed here, you already know how they are run.
```

That turns a self-referential footer into a **third place to contribute**, which is the point of having it in a README at all.

**Both claims in that section were verified rather than assumed.** `gh repo view --json licenseInfo` reports `NONE` for both repos; the licence API and the 11,357-byte `LICENSE` files say **Apache-2.0**. And YazSes really does have **30 open `good first issue`s**, as its entry claims.

## The other two

| Where | Was | Now |
|---|---|---|
| README, Maintainer | "created, **led, and maintained** by" — three claims where one is load-bearing | created it and maintains it today, **and the shipped code is the work of the people named below as well** |
| `GOVERNANCE.md` | "is currently led by **the author**" — the same phrase, in the document that defines the contributor ladder | "who currently leads it and holds the copyright…" |

## What did not change

No behavioural claim, and no credit was moved. **"One maintainer today" is still stated plainly in both files** — it is true, and a contributor deciding whether to invest an evening deserves to know it. The fix is to stop implying that everyone else's work does not exist, not to hide the project's size.

No dead anchor: nothing in the repo linked to `#other-projects-by-the-same-author`.

## Gates run

```
roster OK — .all-contributorsrc and the README table name the same 14 contributors
file modes OK — 961 file(s) ... executable if and only if they have a shebang
syntax OK — 568 tracked Python files outside v1-v3 compile with no SyntaxWarning
encoding OK — 568 tracked Python files outside v1-v3 name an encoding
```

Docs only; no Python touched.