### PR TITLE
fix(coordinator): ground command examples and sequence name discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ uv run ruff check packages/kubeintellect-server/app/ packages/ki-protocol/ packa
 # 2. Types — the workspace is at ZERO errors; keep it there.
 uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube-q/kube_q
 
-# 3. Server suite (5562 tests)
+# 3. Server suite (5563 tests)
 uv run python -m pytest tests/ -q
 
 # 4. kq CLI suite (749 tests)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ uv run ruff check packages/kubeintellect-server/app/ packages/ki-protocol/ packa
 # 2. Types — the workspace is at ZERO errors; keep it there.
 uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube-q/kube_q
 
-# 3. Server suite (5584 tests)
+# 3. Server suite (5590 tests)
 uv run python -m pytest tests/ -q
 
 # 4. kq CLI suite (749 tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **The coordinator prompt taught the model to emit `<ns>` literally**
+  (`app/agent/nodes/coordinator.py`, `app/tools/output_policy.py`, fixed by
+  [@biggdawg320](https://github.com/biggdawg320), #207, closes the prompt half of #173).
+  Every kubectl example in the system prompt used metavariables — `-n <ns>`, `<name>`,
+  `--grace-period=<N>` — eighteen times over. A model copies the shape it is shown, so it
+  emitted `<ns>` verbatim, the kubectl guard rejected the command for containing shell
+  metacharacters, and the run failed. The examples now use concrete illustrative values
+  (`shop`, `payments-api`, `worker-1`) with an explicit instruction that they are
+  illustrative, that they must be substituted from discovery, and that a name must never
+  be guessed to make a command executable.
+
+  `describe node` was also dropped from the "Parallel (always)" batch, which had told the
+  model to describe a node in the same parallel batch that discovers which node to look at.
+
+  `v4/tests/test_coordinator_command_examples.py` keeps the examples grounded. It counts a
+  line as a command example if it names a CLI this project drives or carries a flag or a
+  `key=` directive — not only if it contains the word `kubectl`, which would have walked
+  past two of the lines this change repaired — and it runs over the Cortex gather and
+  synthesis prompts too, since the truncation clause is spliced into all three.
+
+  Still open in #173: `app/tools/kubectl_errors.py` hands metavariables back to the model
+  on the error path (`re-run \`kubectl get pods -n <ns>\``), with hints enabled by default.
+  That is the same failure at the moment the model is most likely to copy a suggestion.
+
 - **`kubeintellect service start` and `service stop` exited 0 after systemd refused**
   (`app/cli.py`, reported and fixed by [@Ryota-Di](https://github.com/Ryota-Di), #208).
   Both called `subprocess.run(...)` and discarded the result, so a unit that failed to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube
 
 # 3. Tests — two suites, run separately: the two `tests` packages collide
 #    under a single pytest invocation.
-uv run python -m pytest tests/ -q                              # server (~5584 tests)
+uv run python -m pytest tests/ -q                              # server (~5590 tests)
 cd packages/kube-q && uv run python -m pytest tests/ -q        # kq CLI (~749 tests)
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube
 
 # 3. Tests — two suites, run separately: the two `tests` packages collide
 #    under a single pytest invocation.
-uv run python -m pytest tests/ -q                              # server (~5562 tests)
+uv run python -m pytest tests/ -q                              # server (~5563 tests)
 cd packages/kube-q && uv run python -m pytest tests/ -q        # kq CLI (~749 tests)
 ```
 

--- a/v4/packages/kubeintellect-server/app/agent/nodes/coordinator.py
+++ b/v4/packages/kubeintellect-server/app/agent/nodes/coordinator.py
@@ -341,7 +341,7 @@ needs that discovery's result. Never send unresolved placeholders or shell
 variables as tool arguments; do not guess names to make a command executable.
 If discovery does not identify the target, report the missing evidence.
 
-Command examples below use illustrative names (shop and payments-api).
+Command examples below use illustrative names (shop, payments-api and worker-1).
 They are not evidence that those resources exist: substitute verified identifiers
 from this investigation before calling a tool.
 
@@ -477,17 +477,19 @@ error message, patching env vars will NOT fix it. The command itself is the bug.
 
 ## Node Drain / Maintenance Plans
 When producing a node drain plan, ALWAYS include ALL three phases:
+Use the same verified node name in every phase; worker-1 below is illustrative.
 
   1. **Cordon** — prevents new pods from being scheduled:
-       kubectl cordon <node>
+       kubectl cordon worker-1
   2. **Drain** — evicts existing pods with PDB awareness:
-       kubectl drain <node> --ignore-daemonsets --delete-emptydir-data
-     Add --grace-period=<N> if pods need a clean shutdown window.
+       kubectl drain worker-1 --ignore-daemonsets --delete-emptydir-data
+     If needed, set --grace-period to a concrete number of seconds based on the
+     workload's shutdown requirements, not an invented default.
      ALWAYS mention PodDisruptionBudgets: if a PDB's minAvailable would be
      violated, drain will wait; use --disable-eviction only in emergencies
      with explicit warnings about PDB bypass.
   3. **Uncordon** — re-enables scheduling after maintenance:
-       kubectl uncordon <node>
+       kubectl uncordon worker-1
      NEVER omit the uncordon step. A drained node stays permanently
      unschedulable until uncordoned.
 

--- a/v4/packages/kubeintellect-server/app/agent/nodes/coordinator.py
+++ b/v4/packages/kubeintellect-server/app/agent/nodes/coordinator.py
@@ -328,9 +328,22 @@ ALWAYS consult this before making tool calls.
 Emit ALL independent tool calls in a SINGLE response. The runtime executes them concurrently.
 Use sequential calls ONLY when the second call depends on the first result.
 
-Parallel (always):   (get pods) + (get events) + (describe node)
+Parallel (independent): (kubectl get pods -A) + (kubectl get events -A)
 Parallel (always):   (loki error query) + (prometheus CPU query)
 Sequential (only):   (get pod name) → (describe that pod) → (patch that pod)
+
+Every resource name, namespace and selector in a tool argument must be concrete
+and grounded in the snapshot, conversation or an earlier tool result. Reuse known
+identifiers before fetching them again. If the node name is unknown, first call
+`kubectl get nodes -o wide`, wait for its result, then describe the relevant node
+by its returned name in a later response. Never batch discovery with a call that
+needs that discovery's result. Never send unresolved placeholders or shell
+variables as tool arguments; do not guess names to make a command executable.
+If discovery does not identify the target, report the missing evidence.
+
+Command examples below use illustrative names (shop and payments-api).
+They are not evidence that those resources exist: substitute verified identifiers
+from this investigation before calling a tool.
 
 ## Investigation Discipline
 For any query that requires tool calls, follow these phases strictly:
@@ -359,8 +372,8 @@ you have genuinely exhausted all investigative paths.
 
 ## Fix Verification (REQUIRED after every mutation)
 After kubectl patch / apply / create / delete, you MUST verify the outcome:
-1. Run kubectl get on the affected resource (e.g. kubectl get pods -n <ns>)
-2. If the fix was for a connectivity issue, ALSO run kubectl get endpoints -n <ns>
+1. Run kubectl get on the affected resource (e.g. kubectl get pods -n shop)
+2. If the fix was for a connectivity issue, ALSO run kubectl get endpoints -n shop
    to confirm traffic can actually reach the pods — a Running pod with a
    mismatched service selector still has endpoints=<none> and is unreachable.
 3. Report ACTUAL state: "Pod is now Running (verified)" or "Fix applied — pod still in <state>"
@@ -378,8 +391,8 @@ On EVERY namespace-level investigation ("check ns X", "what's wrong in X",
 "solve issues in X", "diagnose X"), include these calls in your INITIAL
 parallel tool batch — alongside `get pods` and `get events`:
 
-  - `kubectl get endpoints -n <ns>`
-  - `kubectl get services -n <ns>`
+  - `kubectl get endpoints -n shop`
+  - `kubectl get services -n shop`
 
 Then flag any service whose ENDPOINTS column is `<none>` while its target pods
 are Running. This is a silent fault — no warning event fires for a selector/label
@@ -390,8 +403,8 @@ When endpoints=<none>, ALWAYS diagnose the cause explicitly:
   - If pods are failing: endpoints are none because pods aren't ready (expected).
   - If pods are Running but endpoints are still <none>: the service selector does
     not match the pod labels. Run:
-      kubectl get svc <name> -n <ns> -o jsonpath='{.spec.selector}'
-      kubectl get pods -n <ns> --show-labels
+      kubectl get svc payments-api -n shop -o jsonpath='{.spec.selector}'
+      kubectl get pods -n shop --show-labels
     and compare. A label mismatch must be called out as a separate root cause.
 
 ## Tool-Selection by Intent (CRITICAL — kubectl is authoritative for cluster state)
@@ -401,7 +414,7 @@ are for *history and aggregations*; kubectl is the source of truth for the
 
   "Events", "warnings", "warning events", "what events occurred":
     - ALWAYS use: kubectl get events --field-selector type=Warning -A
-      (or `-n <ns>` when the question scopes to one namespace).
+      (or `-n shop` when the question scopes to one namespace).
     - DO NOT use query_prometheus for events. Prometheus does not store
       Kubernetes events; you will get metric data that does not answer the
       question.
@@ -411,14 +424,14 @@ are for *history and aggregations*; kubectl is the source of truth for the
     - ALWAYS read the pod spec via kubectl:
         kubectl get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\t"}{.spec.containers[*].resources.limits}{"\n"}{end}'
       or, for a single pod:
-        kubectl get pod <name> -n <ns> -o jsonpath='{.spec.containers[*].resources}'
+        kubectl get pod payments-api-7b9d8f6c5-x2k4m -n shop -o jsonpath='{.spec.containers[*].resources}'
     - Prometheus exposes USAGE (`container_memory_working_set_bytes`,
       `container_cpu_usage_seconds_total`) — never the spec. Use Prometheus
       only to compare actual usage against the spec values you read with
       kubectl.
 
   "Endpoints", "service has no endpoints", "is the service reachable":
-    - ALWAYS use: kubectl get endpoints -n <ns> + kubectl get services -n <ns>.
+    - ALWAYS use: kubectl get endpoints -n shop + kubectl get services -n shop.
     - DO NOT infer reachability from Prometheus scrape success — a missing
       endpoint shows up as `<none>` in `kubectl get endpoints` and is the
       authoritative signal.
@@ -505,7 +518,8 @@ Output format selection (CRITICAL — pick the simplest format that works):
 
 For setting a container `command` or `args` (which usually contain `;` or `&&`),
 the ONLY reliable path is:
-  1. `kubectl get <kind> <name> -n <ns> -o yaml` to fetch the current spec.
+  1. Fetch the current spec using the verified resource kind and name, for example
+     `kubectl get deployment payments-api -n shop -o yaml` for a Deployment.
   2. Build the corrected manifest in your response.
   3. `kubectl apply -f -` with the manifest passed via stdin.
 
@@ -541,8 +555,8 @@ SIMPLE — answer directly from the Cluster Snapshot and/or tool calls.
   Use for: list requests, status checks, single-resource lookups, mutations.
   When listing resources, always show COMPLETE raw output in a code block.
 
-TARGETED — emit exactly on its own line:
-  TARGETED: namespace=<ns>, pod=<pod>, issue=<one-line description>
+TARGETED — emit on its own line using the actual namespace, pod name and observed issue; example:
+  TARGETED: namespace=shop, pod=payments-api-7b9d8f6c5-x2k4m, issue=container repeatedly exits with code 1
   Use for: ONE specific resource is failing and needs deeper investigation
   (describe, events, deployment check). The system runs parallel reads and
   returns the results to you for the final answer.
@@ -571,7 +585,7 @@ When synthesizing subagent findings (messages contain <findings> XML):
 IMPORTANT — Truncated output:
   If any tool output contains a truncation marker (text like "[truncated" or "chars omitted"),
   you MUST include a visible warning in your response, for example:
-  "> ⚠️ Output was truncated — use narrower filters (e.g. `-n <namespace>`, `-l <label>`, `--tail`) to see the full result."
+  "> ⚠️ Output was truncated — use narrower filters (e.g. a verified namespace with -n, a verified label selector with -l, or a smaller --tail limit) to see the full result."
   Never silently drop this warning. The user must know the list is incomplete.
 """.replace("{premise_clause}", PREMISE_CLAUSE)
 

--- a/v4/packages/kubeintellect-server/app/agent/nodes/coordinator.py
+++ b/v4/packages/kubeintellect-server/app/agent/nodes/coordinator.py
@@ -587,7 +587,7 @@ When synthesizing subagent findings (messages contain <findings> XML):
 IMPORTANT — Truncated output:
   If any tool output contains a truncation marker (text like "[truncated" or "chars omitted"),
   you MUST include a visible warning in your response, for example:
-  "> ⚠️ Output was truncated — use narrower filters (e.g. a verified namespace with -n, a verified label selector with -l, or a smaller --tail limit) to see the full result."
+  "> ⚠️ Output was truncated — narrow the query with `-n`, `-l`, or `--tail` to see the full result."
   Never silently drop this warning. The user must know the list is incomplete.
 """.replace("{premise_clause}", PREMISE_CLAUSE)
 

--- a/v4/packages/kubeintellect-server/app/tools/output_policy.py
+++ b/v4/packages/kubeintellect-server/app/tools/output_policy.py
@@ -47,7 +47,7 @@ MARKER_PATTERNS = ("[truncated", "chars omitted")
 TRUNCATION_CLAUSE = """IMPORTANT — Truncated output:
   If any tool output contains a truncation marker (text like "[truncated" or "chars omitted"),
   you MUST include a visible warning in your response, for example:
-  "> ⚠️ Output was truncated — use narrower filters (e.g. a verified namespace with -n, a verified label selector with -l, or a smaller --tail limit) to see the full result."
+  "> ⚠️ Output was truncated — narrow the query with `-n`, `-l`, or `--tail` to see the full result."
   Never silently drop this warning. The user must know the list is incomplete."""
 
 

--- a/v4/packages/kubeintellect-server/app/tools/output_policy.py
+++ b/v4/packages/kubeintellect-server/app/tools/output_policy.py
@@ -47,7 +47,7 @@ MARKER_PATTERNS = ("[truncated", "chars omitted")
 TRUNCATION_CLAUSE = """IMPORTANT — Truncated output:
   If any tool output contains a truncation marker (text like "[truncated" or "chars omitted"),
   you MUST include a visible warning in your response, for example:
-  "> ⚠️ Output was truncated — use narrower filters (e.g. `-n <namespace>`, `-l <label>`, `--tail`) to see the full result."
+  "> ⚠️ Output was truncated — use narrower filters (e.g. a verified namespace with -n, a verified label selector with -l, or a smaller --tail limit) to see the full result."
   Never silently drop this warning. The user must know the list is incomplete."""
 
 

--- a/v4/tests/test_coordinator_command_examples.py
+++ b/v4/tests/test_coordinator_command_examples.py
@@ -1,15 +1,79 @@
-"""Prompt examples must not teach unresolved command arguments."""
+"""Prompt examples must not teach unresolved command arguments.
+
+A model copies the shape it is shown. When the coordinator prompt demonstrated
+`kubectl get pods -n <ns>` eighteen times, the model emitted `<ns>` literally, the
+kubectl guard rejected it for containing shell metacharacters, and the run failed
+(#173). The repair was to ground every example in concrete illustrative values.
+
+This gate keeps them grounded. It scans anywhere a placeholder could be read as
+part of a command — not only lines that happen to contain the word `kubectl`,
+because the shape is just as copyable on a bare `-n` line or in a `key=value`
+directive, and two of the lines the original repair fixed were exactly those.
+"""
 import re
 
+import pytest
+
 from app.agent.nodes.coordinator import _COORDINATOR_SYSTEM
+from app.cortex import graph as cortex_graph
+from app.tools.output_policy import TRUNCATION_CLAUSE
+
+# `<...>` shapes that are not command arguments and must never be flagged:
+#   <none>     — what kubectl actually prints in an empty ENDPOINTS column
+#   <findings> — an XML tag the synthesis step is told to expect
+#   <state>, <metric> — slots in quoted sentences the model prints to a human,
+#                       not arguments it substitutes into a command
+_NOT_ARGUMENTS = {"<none>", "<findings>", "<state>", "<metric>"}
+
+# A line is command-ish if it names a CLI this project drives, or carries a flag.
+_COMMAND_LINE = re.compile(
+    r"(?:\b(?:kubectl|helm|logcli|promtool)\b"      # a CLI we actually invoke
+    r"|(?<![\w-])-[a-zA-Z](?![\w-])"                # a short flag: -n, -l, -c
+    r"|--[a-z][a-z-]*"                              # a long flag: --tail, --grace-period
+    r"|\b[a-z_]+=)"                                 # a key=value directive, e.g. namespace=
+)
+_PLACEHOLDER = re.compile(r"<[A-Za-z][A-Za-z0-9_.-]*>")
+
+_PROMPTS = {
+    "coordinator": _COORDINATOR_SYSTEM,
+    "truncation_clause": TRUNCATION_CLAUSE,
+    "cortex_gather": cortex_graph._GATHER_SYSTEM,
+    "cortex_synthesis": cortex_graph._SYNTHESIS_SYSTEM,
+}
 
 
-def test_command_examples_have_no_unresolved_metavariables():
-    # Match lower- and upper-case placeholders, including --grace-period=<N>.
-    # JSONPath braces and the literal output sentinel <none> are not arguments
-    # on kubectl command lines and must not be confused with metavariables.
-    hits = re.findall(
-        r"(?:kubectl[^\n]*|--[a-z][a-z-]*=)<[A-Za-z][A-Za-z0-9_.-]*>[^\n]*",
-        _COORDINATOR_SYSTEM,
-    )
-    assert hits == [], hits
+def _offenders(prompt: str) -> list[str]:
+    hits = []
+    for line in prompt.splitlines():
+        if not _COMMAND_LINE.search(line):
+            continue
+        for ph in _PLACEHOLDER.findall(line):
+            if ph not in _NOT_ARGUMENTS:
+                hits.append(f"{ph}  in: {line.strip()}")
+    return hits
+
+
+@pytest.mark.parametrize("name", sorted(_PROMPTS))
+def test_command_examples_have_no_unresolved_metavariables(name):
+    assert _offenders(_PROMPTS[name]) == [], _offenders(_PROMPTS[name])
+
+
+def test_the_gate_would_catch_the_shapes_that_caused_173():
+    """The regression this gate exists for, in every shape it reached us in.
+
+    The first is what #173 actually produced. The others are the lines the
+    original repair fixed that a `kubectl`-anchored pattern walks straight past —
+    without them the gate is green while the thing it guards has regressed.
+    """
+    assert _offenders("  kubectl get pods -n <ns>")
+    assert _offenders("  TARGETED: namespace=<ns>, resource=<name>")
+    assert _offenders('  "use narrower filters (e.g. `-n <namespace>`)"')
+    assert _offenders("  kubectl delete pod x --grace-period=<N>")
+
+
+def test_the_gate_does_not_flag_output_sentinels_or_prose():
+    """`<none>` is kubectl's own output, not an argument — flagging it would
+    push someone to reword a correct instruction to appease the gate."""
+    assert _offenders("  flag any service whose ENDPOINTS column is `<none>`") == []
+    assert _offenders("  messages contain <findings> XML") == []
+    assert _offenders('  Report: "Fix applied — pod still in <state>"') == []

--- a/v4/tests/test_coordinator_command_examples.py
+++ b/v4/tests/test_coordinator_command_examples.py
@@ -1,0 +1,15 @@
+"""Prompt examples must not teach unresolved command arguments."""
+import re
+
+from app.agent.nodes.coordinator import _COORDINATOR_SYSTEM
+
+
+def test_command_examples_have_no_unresolved_metavariables():
+    # Match lower- and upper-case placeholders, including --grace-period=<N>.
+    # JSONPath braces and the literal output sentinel <none> are not arguments
+    # on kubectl command lines and must not be confused with metavariables.
+    hits = re.findall(
+        r"(?:kubectl[^\n]*|--[a-z][a-z-]*=)<[A-Za-z][A-Za-z0-9_.-]*>[^\n]*",
+        _COORDINATOR_SYSTEM,
+    )
+    assert hits == [], hits


### PR DESCRIPTION
## What & why
The coordinator's parallel example suggested describing a node before its name was known, and its command examples taught angle-bracket placeholders. This addresses the standalone **prompt-side** contribution offered in #173: discovery must finish before dependent calls, identifiers must come from evidence, and examples use concrete illustrative values with explicit substitution guidance. The truncation warning's shared clause is updated consistently.

Related to #173; **does not close it**. The pre-execution guard and a model/tool-call sequencing regression remain separate work. Prompt instructions alone cannot guarantee model compliance.

## Type and scope
- [x] Bug fix / prompt guidance, v4 only
- [x] Existing approval, RBAC and kubectl safety gates preserved
- [x] No secret values introduced

## Validation
- Coordinator/routing, parallel isolation and kubectl tests: 105 passed (Python 3.12).
- Shared truncation/prompt tests: 35 passed on Python 3.12 and 3.13 after correcting a shared-clause mismatch caught by the full run.
- Ruff passes; Linux-targeted mypy passes (193 files); syntax (Python 3.13), encoding and contributor roster gates pass; doc claims match; git diff --check passes.
- Review correction: the original local audit missed `<node>` and `<N>` and its zero result was too narrow. A committed regression test now detects command metavariables and standalone flag values; it failed on all four omitted examples before correction and passes afterward. Cordon/drain/uncordon now use a verified-name example; grace period is expressed in prose. 136 focused tests pass on Python 3.12 and 3.13, including the new gate. Generated test counts refreshed to5563. This checks prompt content, not live LLM behavior.
- Full server suites ran on both interpreters before the shared-clause correction: each 81 failed, 5369 passed, 106 skipped, 6 errors. One failure was the clause mismatch fixed above; all other failure/error names match the previously recorded Windows baseline (80 failures/6 errors). No fresh full baseline rerun or claim of a green full suite.
- Full CLI suites: each 739 passed, 10 failed; failure names match the prior Windows baseline.
- No live cluster or paid LLM evaluation performed. The added test is non-executable (git mode100644) and has no shebang; the full file-mode gate was not rerun for this revision.

## Notes for reviewers
Substantial AI assistance: Codex performed implementation and local validation under Jim Hall's direction. This is intentionally the independently offered prompt contribution; it does not implement the runtime guard or guarantee that placeholders can never reach a tool.