### PR TITLE
fix: propagate service start and stop failures

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -162,7 +162,9 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/53958043?v=4",
       "profile": "https://github.com/Ryota-Di",
       "contributions": [
-        "inflight"
+        "bug",
+        "code",
+        "test"
       ]
     },
     {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ uv run ruff check packages/kubeintellect-server/app/ packages/ki-protocol/ packa
 # 2. Types — the workspace is at ZERO errors; keep it there.
 uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube-q/kube_q
 
-# 3. Server suite (5562 tests)
+# 3. Server suite (5564 tests)
 uv run python -m pytest tests/ -q
 
 # 4. kq CLI suite (749 tests)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ uv run ruff check packages/kubeintellect-server/app/ packages/ki-protocol/ packa
 # 2. Types — the workspace is at ZERO errors; keep it there.
 uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube-q/kube_q
 
-# 3. Server suite (5578 tests)
+# 3. Server suite (5584 tests)
 uv run python -m pytest tests/ -q
 
 # 4. kq CLI suite (749 tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`kubeintellect service start` and `service stop` exited 0 after systemd refused**
+  (`app/cli.py`, reported and fixed by [@Ryota-Di](https://github.com/Ryota-Di), #208).
+  Both called `subprocess.run(...)` and discarded the result, so a unit that failed to
+  start reported success to the caller — and to any script or CI step that trusted the
+  exit code. They now propagate systemd's own return code.
+
+  The fix is narrower than it looks, and deliberately so: `service status` and
+  `service logs` keep discarding theirs, because `systemctl status` returns non-zero for
+  a perfectly valid inactive unit and `journalctl -f` returns non-zero when the operator
+  presses Ctrl-C. Treating either as a failure would have traded one wrong answer for
+  another. Those two entries stay in the audit allowlist with that reasoning written out.
+
+  `systemctl --user start` and `stop` were added to `_MUST_STAY_CHECKED`, and the success
+  path gained a test of its own: the failure test pins the code that is propagated, but
+  nothing held the other side, so `sys.exit(proc.returncode or 1)` — the shape a later
+  cleanup reaches for — would have turned every successful start into exit 1 with the
+  suite still green.
+
 ## [2.5.0] – 2026-09-12
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube
 
 # 3. Tests — two suites, run separately: the two `tests` packages collide
 #    under a single pytest invocation.
-uv run python -m pytest tests/ -q                              # server (~5562 tests)
+uv run python -m pytest tests/ -q                              # server (~5564 tests)
 cd packages/kube-q && uv run python -m pytest tests/ -q        # kq CLI (~749 tests)
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube
 
 # 3. Tests — two suites, run separately: the two `tests` packages collide
 #    under a single pytest invocation.
-uv run python -m pytest tests/ -q                              # server (~5578 tests)
+uv run python -m pytest tests/ -q                              # server (~5584 tests)
 cd packages/kube-q && uv run python -m pytest tests/ -q        # kq CLI (~749 tests)
 ```
 

--- a/v4/packages/kubeintellect-server/app/cli.py
+++ b/v4/packages/kubeintellect-server/app/cli.py
@@ -780,9 +780,13 @@ def cmd_service(args: argparse.Namespace) -> None:
             sys.exit(1)
         print(_ok("✓  Service removed."))
     elif action == "start":
-        subprocess.run(["systemctl", "--user", "start", _SERVICE_NAME])
+        proc = subprocess.run(["systemctl", "--user", "start", _SERVICE_NAME])
+        if proc.returncode != 0:
+            sys.exit(proc.returncode)
     elif action == "stop":
-        subprocess.run(["systemctl", "--user", "stop", _SERVICE_NAME])
+        proc = subprocess.run(["systemctl", "--user", "stop", _SERVICE_NAME])
+        if proc.returncode != 0:
+            sys.exit(proc.returncode)
     elif action == "status":
         subprocess.run(["systemctl", "--user", "status", _SERVICE_NAME])
     elif action == "logs":

--- a/v4/tests/test_no_unchecked_subprocess_success.py
+++ b/v4/tests/test_no_unchecked_subprocess_success.py
@@ -40,13 +40,16 @@ _REVIEWED: dict[tuple[str, str], str] = {
         "install's returncode and stays true regardless; a failed patch surfaces as an "
         "unreachable Loki in `kubeintellect status`"
     ),
-    ("cli.py", "systemctl --user start"): (
-        "`service start|stop|status` pass systemctl's own stdout and stderr straight through to "
-        "the terminal — no capture_output, and no ✓ printed afterwards"
+    ("cli.py", "systemctl --user status"): (
+        "`service status` is a query: systemctl may return non-zero for a valid service state "
+        "such as inactive, so its returncode is not treated as a command failure; stdout and "
+        "stderr are passed through directly"
     ),
-    ("cli.py", "systemctl --user stop"): "as `service start`",
-    ("cli.py", "systemctl --user status"): "as `service start`",
-    ("cli.py", "journalctl --user -u"): "`service logs` streams journalctl to the terminal, tail -f style",
+    ("cli.py", "journalctl --user -u"): (
+        "`service logs` is an interactive follow command; journalctl -f normally runs until "
+        "the user interrupts it, so its eventual returncode is not treated as the success or "
+        "failure of starting log viewing"
+    ),
 }
 
 # Signatures that were the pass-192 defects. They must never come back.
@@ -183,6 +186,25 @@ class TestTheCommandsThemselves:
 
         ok, detail = _run_quietly(["sleep", "5"], timeout=1)
         assert ok is False and "sleep" in detail
+
+    @pytest.mark.parametrize("action", ["start", "stop"])
+    def test_service_start_and_stop_propagate_systemctl_failure(
+        self, monkeypatch, action
+    ):
+        import argparse
+
+        from app import cli
+
+        def fake_run(cmd, **kwargs):
+            assert cmd == ["systemctl", "--user", action, cli._SERVICE_NAME]
+            return subprocess.CompletedProcess(cmd, 5)
+
+        monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+        with pytest.raises(SystemExit) as exit_info:
+            cli.cmd_service(argparse.Namespace(action=action))
+
+        assert exit_info.value.code == 5
 
     def test_uninstall_reports_a_refused_disable(self, tmp_path, monkeypatch, capsys):
         """`service uninstall` must not print "Service removed" when systemd refused."""

--- a/v4/tests/test_no_unchecked_subprocess_success.py
+++ b/v4/tests/test_no_unchecked_subprocess_success.py
@@ -57,6 +57,11 @@ _MUST_STAY_CHECKED = (
     "kubectl apply -f",
     "systemctl --user restart",
     "systemctl --user disable",
+    # `start` and `stop` exited 0 after systemd refused, until #208. Deleting their
+    # `_REVIEWED` entries is what stops the discarded shape returning; listing them here
+    # is what stops the entry being written back, which is the easier mistake to make.
+    "systemctl --user start",
+    "systemctl --user stop",
 )
 
 
@@ -205,6 +210,27 @@ class TestTheCommandsThemselves:
             cli.cmd_service(argparse.Namespace(action=action))
 
         assert exit_info.value.code == 5
+
+    @pytest.mark.parametrize("action", ["start", "stop"])
+    def test_service_start_and_stop_stay_silent_on_success(self, monkeypatch, action):
+        """A successful start/stop must return normally, not exit.
+
+        The failure path above pins the code that is propagated; nothing pinned the
+        success path, so `sys.exit(proc.returncode or 1)` — the shape a later cleanup
+        reaches for — would turn every successful `service start` into exit 1 with the
+        whole suite still green.
+        """
+        import argparse
+
+        from app import cli
+
+        def fake_run(cmd, **kwargs):
+            assert cmd == ["systemctl", "--user", action, cli._SERVICE_NAME]
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+        cli.cmd_service(argparse.Namespace(action=action))  # must not raise SystemExit
 
     def test_uninstall_reports_a_refused_disable(self, tmp_path, monkeypatch, capsys):
         """`service uninstall` must not print "Service removed" when systemd refused."""


### PR DESCRIPTION
<!--
Thanks for contributing to KubeIntellect! 💙
Please fill this out so reviewers can move fast. See CONTRIBUTING.md for the full guide.
-->

## What & why

`kubeintellect service start` and `kubeintellect service stop` now propagate a non-zero exit code when the underlying `systemctl` command fails.

Previously, `subprocess.run(...)` was called without inspecting its result, so `systemctl` could fail while the kubeintellect CLI still exited successfully with code 0.

This PR:

* checks the `systemctl` return code for `service start` and `service stop`
* propagates the underlying non-zero exit code
* adds regression coverage for both commands
* removes the repaired `start` / `stop` calls from `_REVIEWED`
* updates the remaining `_REVIEWED` reasoning for `status` and `logs` to explicitly address exit-code semantics
* updates the documented server test count after adding the two parametrized regression cases

### Why `status` and `logs` are unchanged

I left `service status` and `service logs` unchanged intentionally.

For `status`, a non-zero `systemctl status` code can describe a valid queried state such as an inactive service, so it should not be blindly treated as failure of the status query itself.

For `logs`, `journalctl -f` is an interactive follow command whose normal lifecycle includes user interruption, so its eventual subprocess return code does not directly represent whether log viewing was successfully started.

Their `_REVIEWED` entries now document these exit-code considerations rather than only noting that stdout/stderr are visible to the user.

### Testing

The regression test was first run against the unmodified implementation and failed as expected for both `start` and `stop`:

```text
FAILED ...[start] - Failed: DID NOT RAISE SystemExit
FAILED ...[stop] - Failed: DID NOT RAISE SystemExit
2 failed
```

After the fix:

```text
17 passed
```

Additional validation:

```text
test_doc_claims_match_code: 1 passed
ruff: All checks passed!
mypy: Success: no issues found in 193 source files
```

I also ran the full server test suite locally. The remaining failures were unrelated to this change and specific to the local macOS environment: the demo GIF tests require a supported monospace font such as DejaVu Sans Mono, and three file-mode tests hit BSD `chmod` behavior.

Closes #189.

## Type of change

* [x] 🐛 Bug fix
* [ ] ✨ New feature
* [x] 📖 Docs
* [ ] 🧹 Refactor / chore
* [ ] ⚡ Performance
* [x] 🧪 Tests

## Scope

* Version directory touched: `v4/` (plus root-level test-count docs)
* [x] This change is scoped to a version whose contributions are open (`v4/`, or docs/typos in older versions).

## Checklist

* [ ] New behavior has both a **happy-path** and an **error-path** test
* [ ] **Adding a playbook?** `triggers:` and `detect:` are two independent features — a test proves
  the compiled `detect:` predicate **fires** on a realistic event and does **not** fire on a
  neighbouring one. The counts and the schema check prove neither. (`kind:` is the observation
  channel — `Pod` / `Event` / `Node` — never the Kubernetes object; use `involved_kind:` to
  narrow the subject.)
* [ ] **Every mutating/write operation keeps its dry-run + diff + human-approval (HITL) gate** (safety invariant)
* [ ] Secret values are never logged or returned (key names only)
* [ ] `uv run pytest` passes locally
* [x] `uv run ruff check .` passes locally
* [x] `uv run mypy src` passes locally
* [x] Docs updated if behavior/CLI/flags changed

<!-- Nothing to sign. No CLA, no DCO sign-off, no `git commit -s` — see LICENSING.md. -->

## Notes for reviewers

The full server suite was run locally on macOS. The failures described above appear environment-specific; the tests directly covering this change, doc-claim validation, lint, and type checking pass locally.
