### PR TITLE
docs: "sole copyright holder" stopped being true, and LICENSING.md said so twice

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,7 +316,7 @@ Two specific asks for this project in particular:
    filter, and it applies identically to hand-written code.
 
 We will never reject a contribution *because* AI was used. We will reject one that is untested,
-doesn't fit the design, or that the author cannot explain — the same bar as always.
+doesn't fit the design, or that its author cannot explain — the same bar as always.
 
 ---
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -57,9 +57,11 @@ Written down now, while it is hypothetical and nobody is upset.
 - **If the project is ever abandoned**, the intent is to archive it publicly with a clear
   notice in the README rather than let it rot silently, and to say so on PyPI. The AGPL means
   the code cannot be taken away from you regardless.
-- **Copyright and the dual license** stay with the author; that is a legal fact, not a
-  governance lever, and it does not affect anyone's AGPL rights. See
-  [LICENSING.md](LICENSING.md).
+- **Copyright in the project's own code, and the dual license, stay with the lead
+  maintainer**; that is a legal fact, not a governance lever, and it does not affect anyone's
+  AGPL rights. **Contributors keep the copyright in their own work** — there is no CLA and no
+  copyright assignment, and the commercial license does not reach contributed code. See
+  [LICENSING.md](LICENSING.md) and [DCO.md](DCO.md).
 
 ### Code of Conduct enforcement
 Reports go to **mohsen.seyedkazemi@gmail.com** and are handled per

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -33,8 +33,10 @@ If the AGPL obligations do not fit your use — for example you want to:
   source, or
 - redistribute it under terms other than the AGPL,
 
-then you need a **commercial license**. As the sole copyright holder, the author can grant
-proprietary terms separately from the AGPL.
+then you need a **commercial license**. The copyright holder can grant proprietary terms
+separately from the AGPL, covering the project's own code — see
+[Contributions](#contributions) below for how that sits alongside code contributed by
+other people, who keep the copyright in their own work.
 
 **To obtain a commercial license, contact:** mohsen.seyedkazemi@gmail.com
 


### PR DESCRIPTION
> ⚠️ **This one touches licensing text — please read the wording before merging.** It is the only change in this series I would not merge on my own judgement.

## The contradiction

`LICENSING.md` disagrees with itself within one screen.

**Line 36**, introducing the commercial licence:

> **As the sole copyright holder**, the author can grant proprietary terms separately from the AGPL.

**Line 54**, its own Contributions section:

> The commercial license above covers **the copyright holder's own code**. It does not reach your contribution, and nothing here asks you to let it.

The second one is correct. This project has **no CLA, no DCO sign-off and no copyright assignment** — deliberately, with the trade-off argued in full in [`DCO.md`](DCO.md) — so every contributor keeps the copyright in their own work. There are now fourteen of them. "Sole copyright holder" was true of a one-person repository and was never revisited.

## Why it is worth fixing rather than leaving

- A **commercial buyer** reads the strongest claim on the page, and it overstated what is on offer.
- A **contributor** reads that their copyright does not exist — on the page that decides whether they are comfortable contributing at all. That is the more expensive failure, and it sits in a repo whose entire current effort is persuading people their work is theirs and is wanted.

## No new legal position is taken

The wording is aligned with what this repository **already says** in three places that were already right: `LICENSING.md`'s own Contributions section, `DCO.md`, and `CONTRIBUTING.md`. Nothing is granted, withdrawn, or invented. If you would prefer different phrasing, the substance to preserve is just: *the commercial licence covers the project's own code, and contributors keep theirs.*

## Two smaller ones in the same family

| File | Was | Why it mattered |
|---|---|---|
| `GOVERNANCE.md` | "**Copyright and the dual license** stay with the author" | Over-broad in the same way, and silent on what contributors keep. Now scoped to the project's own code, and says plainly that contributors keep theirs |
| `CONTRIBUTING.md` | "that **the author** cannot explain" | Here "the author" means the *pull request's* author — but "the author" meant the maintainer everywhere else in these docs. Now "its author" |

## Gates run

```
roster OK — .all-contributorsrc and the README table name the same 14 contributors
file modes OK — 961 file(s) ... executable if and only if they have a shebang
syntax OK — 568 tracked Python files outside v1-v3 compile with no SyntaxWarning
encoding OK — 568 tracked Python files outside v1-v3 name an encoding
```

Docs only; no Python touched. The `#contributions` anchor exists in `LICENSING.md` (line 48).