### PR TITLE
feat(playbooks): add evidence-based Ingress TLS expiry triage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ uv run ruff check packages/kubeintellect-server/app/ packages/ki-protocol/ packa
 # 2. Types — the workspace is at ZERO errors; keep it there.
 uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube-q/kube_q
 
-# 3. Server suite (5562 tests)
+# 3. Server suite (5584 tests)
 uv run python -m pytest tests/ -q
 
 # 4. kq CLI suite (749 tests)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ uv run mypy packages/kubeintellect-server/app packages/ki-protocol packages/kube
 
 # 3. Tests — two suites, run separately: the two `tests` packages collide
 #    under a single pytest invocation.
-uv run python -m pytest tests/ -q                              # server (~5562 tests)
+uv run python -m pytest tests/ -q                              # server (~5584 tests)
 cd packages/kube-q && uv run python -m pytest tests/ -q        # kq CLI (~749 tests)
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,7 @@ The `v4/` platform is the current line and the only one you should deploy.
 - Conversational diagnosis correlating **kubectl + Prometheus + Loki**.
 - **Human-in-the-loop approval gate** with RBAC (superadmin / admin / operator / readonly) on
   every mutating action, enforced server-side at the mutating chokepoint.
-- **26 declarative failure playbooks** (`detect → investigate → remediate`), 20 of which compile
+- **27 declarative failure playbooks** (`detect → investigate → remediate`), 20 of which compile
   to zero-token detectors.
 - **Zero-token detection** — a detector engine over a kubectl `--watch` sensorium fires
   findings without invoking the LLM.
@@ -51,7 +51,7 @@ These are concrete, scoped, and mostly open to contribution.
 | **Composable detectors** — AND / NOT / temporal windows | Open | [#21](https://github.com/MSKazemi/kubeintellect/issues/21) ✅ |
 | **PromQL execution in playbook `detect` blocks** | Open | [#20](https://github.com/MSKazemi/kubeintellect/issues/20) ✅ |
 | **Temporal KG ingesting nodes / events / PVCs** | Open | [#19](https://github.com/MSKazemi/kubeintellect/issues/19) ✅ |
-| Grow the **playbook library** beyond 26 | Ongoing — a playbook is one YAML file; 18 → 23 in Aug 2026 via [#108](https://github.com/MSKazemi/kubeintellect/pull/108), [#112](https://github.com/MSKazemi/kubeintellect/pull/112), [#114](https://github.com/MSKazemi/kubeintellect/pull/114), [#127](https://github.com/MSKazemi/kubeintellect/pull/127) and [#128](https://github.com/MSKazemi/kubeintellect/pull/128) | [#13](https://github.com/MSKazemi/kubeintellect/issues/13) ✅ |
+| Grow the **playbook library** beyond 27 | Ongoing — a playbook is one YAML file; 18 → 23 in Aug 2026 via [#108](https://github.com/MSKazemi/kubeintellect/pull/108), [#112](https://github.com/MSKazemi/kubeintellect/pull/112), [#114](https://github.com/MSKazemi/kubeintellect/pull/114), [#127](https://github.com/MSKazemi/kubeintellect/pull/127) and [#128](https://github.com/MSKazemi/kubeintellect/pull/128) | [#13](https://github.com/MSKazemi/kubeintellect/issues/13) ✅ |
 
 ## Housekeeping — known debt, stated plainly
 

--- a/v4/docs/agent-behaviors.md
+++ b/v4/docs/agent-behaviors.md
@@ -236,7 +236,7 @@ detects a matching pattern in the snapshot, the coordinator's system prompt
 includes the playbook(s) inline — guiding it to follow proven steps before
 improvising.
 
-**Playbooks shipped (26):**
+**Playbooks shipped (27):**
 
 *Pod / container lifecycle*
 
@@ -703,7 +703,7 @@ change; zero allowed disruptions by itself can be intentional availability polic
     threshold on the first scrape. That depends on runtime values, so it belongs to a
     shadow period and a human, not to a validator.
 
-Of the 26 shipped playbooks, **20 compile to detectors**; 4 are LLM-only
+Of the 27 shipped playbooks, **20 compile to detectors**; 4 are LLM-only
 (`CommandHardcodedFailure` — disambiguated from CrashLoopBackOff only by
 reading the pod spec — `ServiceUnreachable`, `NetworkPolicyBlocking`,
 where the packet is discarded in the CNI datapath so no machine signal

--- a/v4/docs/architecture.md
+++ b/v4/docs/architecture.md
@@ -487,7 +487,7 @@ packages/
 │   │   ├── coordinator.py        — LLM decision + synthesis, tool trimmer, reflexion writes
 │   │   ├── memory_loader.py      — load pinned cluster context + failure-pattern hints
 │   │   └── subagent.py           — 4 specialist subagent runners
-│   ├── playbooks/                — YAML playbook library + loader (26 playbooks)
+│   ├── playbooks/                — YAML playbook library + loader (27 playbooks)
 │   ├── state.py                  — AgentState, SubagentInput, AgentFinding, RCAResult
 │   ├── workflow.py               — LangGraph graph, targeted_investigator, route_coordinator
 │   └── hitl.py                   — HITL approval/denial detection

--- a/v4/docs/capabilities.md
+++ b/v4/docs/capabilities.md
@@ -36,7 +36,7 @@ Metrics and logs are optional — without them, KubeIntellect still answers ever
 
 V4 also works *between* your questions:
 
-- **Zero-token known-failure detection** — the playbook library covers the 26 most common failures, and compiled detectors recognize 20 of them straight off the live cluster stream without spending a single LLM token. → [Agent Behaviors → V4 additions](agent-behaviors.md#v4-additions)
+- **Zero-token known-failure detection** — the playbook library covers the 27 most common failures, and compiled detectors recognize 20 of them straight off the live cluster stream without spending a single LLM token. → [Agent Behaviors → V4 additions](agent-behaviors.md#v4-additions)
 - **Self-opened investigations** — a firing detector opens its own investigation and publishes the report; how far it may go is set per namespace (A0–A3). → [Autonomous Operations](autonomy.md)
 - **Morning digest** — `kq digest` summarizes findings, autonomous investigations, and rollback points from the last N hours. → [Autonomous Operations → digest](autonomy.md#the-morning-digest)
 - **Tamper-evident audit replay** — every session is hash-chained in an append-only log; `kq replay <session-id>` reproduces it and verifies integrity. → [Flight Recorder & Replay](flight-recorder.md)
@@ -48,7 +48,7 @@ V4 also works *between* your questions:
 
 ## Failure patterns it recognizes
 
-KubeIntellect ships **26 built-in playbooks** — deterministic investigation
+KubeIntellect ships **27 built-in playbooks** — deterministic investigation
 recipes for the most common Kubernetes failures. When the cluster snapshot
 matches a pattern, the matching playbook guides the investigation automatically.
 You don't invoke these by name; they fire on their own.

--- a/v4/docs/examples.md
+++ b/v4/docs/examples.md
@@ -495,7 +495,7 @@ See [CLI Reference → `kq export`](cli-reference.md#kq-export-session-id).
 
 ## 14 · Teach it a new failure — `kq detector`
 
-Your cluster fails in a way the 26 shipped playbooks do not cover, and you want it recognised without writing Python.
+Your cluster fails in a way the 27 shipped playbooks do not cover, and you want it recognised without writing Python.
 
 **You run:**
 

--- a/v4/docs/faq.md
+++ b/v4/docs/faq.md
@@ -144,7 +144,7 @@ Plain ChatGPT can't see your cluster; KubeIntellect grounds every answer in live
 `kubectl` / Helm / Prometheus / Loki data. Beyond running commands, it adds
 capabilities those command-shaped tools don't combine: **parallel specialist
 subagents** (pod / metrics / logs / events) that fan out for a real root-cause
-analysis, **26 deterministic playbooks** that guide known-failure investigations,
+analysis, **27 deterministic playbooks** that guide known-failure investigations,
 a **human-in-the-loop approval gate** on every write, a **memory + reflexion**
 layer that recalls past incidents and promotes verified fixes, and an **autonomy**
 layer that opens its own investigations when a detector fires. See

--- a/v4/docs/glossary.md
+++ b/v4/docs/glossary.md
@@ -18,7 +18,7 @@ page where the concept is explained in depth.
 | **Memory loader** | The step that loads pinned, cross-session context (user prefs, past root causes, failure hints) into the prompt. Active only on PostgreSQL. |
 | **Cluster snapshot** | The pre-fetched picture of cluster health (pod list + Warning events) built at the start of every turn. Drives playbook matching and the snapshot sufficiency gate. |
 | **Snapshot sufficiency gate** | A soft bias that lets the agent answer healthy, list-shaped questions straight from the snapshot instead of re-querying. Modes: `off` / `lenient` / `strict`. See [Agent Behaviors](agent-behaviors.md#snapshot-sufficiency-gate). |
-| **Playbook** | A YAML investigation recipe for a known failure (CrashLoopBackOff, OOMKilled, …). When the snapshot matches, the playbook is injected into the prompt to guide the agent. 26 ship by default. See [Playbook library](agent-behaviors.md#playbook-library). |
+| **Playbook** | A YAML investigation recipe for a known failure (CrashLoopBackOff, OOMKilled, …). When the snapshot matches, the playbook is injected into the prompt to guide the agent. 27 ship by default. See [Playbook library](agent-behaviors.md#playbook-library). |
 | **Investigation plan** | A visible, up-front checklist the agent emits for queries needing 3+ steps, streamed as a `plan` event so the UI can show it. |
 | **RCA** | **Root-Cause Analysis** — the deep investigation path where four subagents run in parallel and the coordinator synthesizes their findings into one conclusion. |
 | **RCAResult** | The structured output of an RCA: root cause, confidence, supporting evidence, conflicting evidence, reasoning, and a recommended fix. See [What you can ask](capabilities.md#what-a-root-cause-answer-looks-like). |

--- a/v4/packages/kubeintellect-server/app/agent/playbooks/tls_certificate_expired.yaml
+++ b/v4/packages/kubeintellect-server/app/agent/playbooks/tls_certificate_expired.yaml
@@ -1,0 +1,47 @@
+name: TlsCertificateExpired
+# Triage-only: client TLS errors are not necessarily Kubernetes Warning Events.
+# These text triggers select a guide when evidence is supplied to the matcher;
+# they do not add endpoint probes, log ingestion, or an automatic expiry monitor.
+# Go's combined error also covers NotBefore: require its same-line "is after" detail.
+# Sources: https://go.dev/src/crypto/x509/verify.go
+#          https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+detect: null
+triggers:
+  - event_message_regex: 'x509: certificate has expired or is not yet valid: current time [0-9T:.+Z-]+ is after '
+  - event_message_regex: '(SSL certificate problem: |certificate verify failed: |verify error:num=10:)certificate has expired'
+investigation_steps:
+  - "Record the failing hostname, port, client error and observation time. This guide covers client-to-Ingress TLS; an expiry error alone does not identify an Ingress. Establish the endpoint owner first. For webhook, kubelet, client-certificate or upstream TLS failures, investigate that connection with its owner rather than changing an Ingress Secret."
+  - "kubectl get ingress -A — find the intended hostname, then kubectl get ingress <ingress> -n <ns> -o yaml to inspect spec.rules, spec.tls hosts/secretName, ingressClassName and status.loadBalancer. Confirm the actual DNS/load-balancer route and controller. TLS may terminate at a CDN or external load balancer instead; SSL passthrough can terminate in the application. Do not assume the referenced Secret is the certificate clients receive."
+  - "Have an authorized operator inspect the certificate actually served for the exact hostname using SNI, from the affected network path. Record leaf and intermediate certificate validity, SANs, issuer, serial/fingerprint and the verification error. Check all relevant endpoint replicas if behavior is intermittent. Do not disable certificate verification as a repair or declare success from a handshake made with verification disabled."
+  - "Compare the failed certificate's notAfter with a trusted current UTC time and check the affected client's clock. A future notBefore is not expiry. Go's combined expired-or-not-yet-valid message needs its is-after detail; confirm the certificate dates independently. Unknown CA, missing intermediates and hostname mismatch require different repairs. An expired intermediate is not proof that the leaf is expired."
+  - "For confirmed Ingress termination, compare the served leaf fingerprint and dates with the certificate in the exact spec.tls Secret in the Ingress namespace. Use approved tooling to inspect only certificate metadata from tls.crt. Never dump Secret YAML/JSON, tls.key, private keys or credentials into chat/logs. If access or safe certificate extraction is unavailable, ask an authorized operator for sanitized metadata and state the evidence gap."
+  - "Determine who manages renewal (for example cert-manager, an external issuer or a manual process) from the deployment configuration. Request sanitized renewal status/errors from that owner. A renewed Secret with an old served certificate points to controller reload, routing or replica inconsistency, not necessarily failed issuance. Missing Secret, wrong hostname and stale references are separate findings; do not diagnose them solely from a TLS error."
+expected_evidence:
+  - "The exact failing endpoint and TLS termination owner, with a timestamped client verification failure"
+  - "Trusted current time is beyond the identified served leaf or intermediate certificate's notAfter; clock skew and future notBefore have been checked"
+  - "The certificate fingerprint, SANs, issuer and relevant Ingress/Secret or external-terminator relationship, with renewal/reload evidence or an explicit access limitation"
+recommended_fix_template: |
+  The certificate <FINGERPRINT> served on <HOST>:<PORT> expired at <NOT_AFTER>,
+  supported by <VERIFICATION_ERROR> at <TRUSTED_UTC_TIME>. The affected certificate
+  is <LEAF_OR_INTERMEDIATE> and TLS is terminated by <VERIFIED_OWNER>.
+  If identity, dates or ownership are unverified, gather evidence before proposing
+  a change. A generic TLS failure or HTTP 5xx is insufficient to diagnose expiry.
+
+  Propose renewal/replacement through the existing certificate owner and approved
+  issuance process, preserving hostname coverage and the required trust chain.
+  If issuance succeeded but an old certificate is still served, investigate the
+  controller's documented reload behavior and endpoint routing before requesting
+  a targeted reload. For external TLS termination, repair that terminator instead
+  of overwriting an unrelated Kubernetes Secret.
+
+  Secret updates, certificate renewal requests, routing changes and restarts require
+  explicit human approval and the existing change-review gate. Use metadata-only
+  or redacted previews; ordinary Secret diffs can disclose private keys. Do not
+  delete Secrets, weaken trust, use insecure-skip-tls-verify, or change webhook
+  failurePolicy to hide the error. This guide performs no mutation automatically.
+
+  After approved remediation, verify the intended certificate and complete chain
+  from the affected client path, with the exact hostname/SNI and verification
+  enabled. Confirm validity dates, hostname coverage, consistent endpoint results
+  and application health. A changed Secret or a healthy pod alone is not proof
+  that clients now receive a valid certificate.

--- a/v4/tests/test_every_playbook_is_reachable.py
+++ b/v4/tests/test_every_playbook_is_reachable.py
@@ -115,10 +115,10 @@ _BUMP_HINT = (
 
 def test_the_inventory_is_actually_covered():
     """Guard the guard: an empty registry would make both tests above pass vacuously."""
-    assert len(_PLAYBOOKS) == 26, (
+    assert len(_PLAYBOOKS) == 27, (
         f"playbook count changed to {len(_PLAYBOOKS)}{_BUMP_HINT}"
     )
-    assert len(_CASES) == 46, (
+    assert len(_CASES) == 48, (
         f"trigger-regex count changed to {len(_CASES)}{_BUMP_HINT}"
     )
 

--- a/v4/tests/test_tls_expiry_playbook.py
+++ b/v4/tests/test_tls_expiry_playbook.py
@@ -1,0 +1,44 @@
+"""Expiry evidence selects triage; generic TLS failures and future validity do not."""
+from __future__ import annotations
+
+import pytest
+
+from app.agent.playbooks import get_playbook, match_playbooks
+
+
+@pytest.mark.parametrize("message", [
+    "x509: certificate has expired or is not yet valid: current time 2026-09-11T00:00:00Z is after 2026-09-10T00:00:00Z",
+    "SSL certificate problem: certificate has expired",
+    "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1000)",
+    "verify error:num=10:certificate has expired",
+])
+def test_expiry_error_selects_triage(message):
+    assert "TlsCertificateExpired" in match_playbooks("", message)
+
+
+@pytest.mark.parametrize("message", [
+    "",
+    "Verify return code: 0 (ok)",
+    "SSL certificate verify ok.",
+    "certificate expires in 30 days",
+    "certificate has not expired",
+    "x509: certificate signed by unknown authority",
+    "x509: certificate is valid for other.example, not shop.example",
+    "SSL certificate problem: certificate is not yet valid",
+    "x509: certificate has expired or is not yet valid: current time 2026-09-10T00:00:00Z is before 2026-09-11T00:00:00Z",
+    "x509: certificate has expired or is not yet valid",
+    "x509: certificate has expired or is not yet valid: current time is before validity\nunrelated task is after deadline",
+    "HTTP/1.1 503 Service Unavailable",
+    "tls: handshake failure",
+    "remote error: tls: bad certificate",
+])
+def test_other_tls_conditions_do_not_assert_expiry(message):
+    assert "TlsCertificateExpired" not in match_playbooks("", message)
+
+
+def test_tls_guide_loads_without_an_automatic_detector():
+    guide = get_playbook("TlsCertificateExpired")
+    assert guide is not None
+    assert guide.detect is None
+    assert guide.investigation_steps
+    assert guide.expected_evidence


### PR DESCRIPTION
## What & why

Related to #13; claims only the Ingress TLS/certificate-expiry topic in https://github.com/MSKazemi/kubeintellect/issues/13#issuecomment-5630085867. Leaves the umbrella issue open.

Add `TlsCertificateExpired`, a triage-only playbook for a certificate actually served to an Ingress client. It requires endpoint/termination ownership, SNI/hostname, certificate identity and trusted time before diagnosing expiry. It distinguishes expired intermediates, clock skew, future validity, external termination and a renewed Secret that is not yet served. No Secret dumping, private-key output, verification bypass, automatic renewal or RBAC expansion.

The Go error says "expired or is not yet valid" in both cases: its trigger requires the same-line timestamp and `is after` detail. Other triggers recognize explicit curl/Python/OpenSSL expiry errors. They select a guide when that text is supplied to the matcher; they do not introduce client/log ingestion or an automatic expiry monitor. `detect: null` is intentional.

## Type and scope

- [x] New playbook, documentation and tests in v4; root documentation counts regenerated.
- [x] New tests run red first: 5 failed / 14 passed before adding the playbook.
- [x] Positive expiry cases and negative healthy, future-validity, unknown-CA, hostname-mismatch, generic handshake/503 and cross-line cases.
- [x] Existing human approval and secret-handling boundaries retained. Certificate/Secret changes are guidance for an authorized operator only.

## Validation

- Final 178 focused tests pass on **both Python 3.12 and 3.13**: new TLS tests, existing playbooks/PDB/StatefulSet, all-trigger reachability and doc-claims tests.
- Ruff passes over the exact CI scope; Linux-targeted mypy passes (193 source files).
- File-mode gate passes (963 indexed files, using an LF-normalized copy of the existing gate under Git Bash); syntax and encoding gates pass (569 tracked Python files); roster passes (14 contributors).
- Generated doc counts verified after staging the new tests; MkDocs builds with existing missing-link/anchor warnings. Whitespace checks pass.
- **Full Windows suites are not green.** Python 3.12 server: 80 failed / 5392 passed / 106 skipped / 6 errors. Python 3.13 server: 81 failed / 5391 passed / 106 skipped / 6 errors. CLI: 10 failed / 739 passed on each interpreter. Server failure/error names match the previously recorded Windows baseline except the 3.13 doc-count failure; that count was regenerated after adding the new test file to the index and passes in both final focused runs. CLI failure names match the previous baseline. This is comparison against recorded baseline logs, not a fresh unchanged-base run. No full-suite rerun after the final documentation-count correction.
- Local staged tree exactly matches the published tree `9b88ff7`.

## Notes for reviewers

No live cluster, endpoint probe, LLM call or paid service used. Routing tests verify candidate selection, not a production expiry diagnosis. Source references: https://go.dev/src/crypto/x509/verify.go and https://kubernetes.io/docs/concepts/services-networking/ingress/#tls .

Prepared and validated with substantial OpenAI Codex assistance under the account owner's direction.