### PR TITLE
feat(playbooks): add TLS certificate expiry failure playbook

### DIFF
--- a/v4/CONTRIBUTING_TMP.txt
+++ b/v4/CONTRIBUTING_TMP.txt
@@ -1,0 +1,1 @@
+placeholder

--- a/v4/CONTRIBUTING_TMP.txt
+++ b/v4/CONTRIBUTING_TMP.txt
@@ -1,1 +1,0 @@
-placeholder

--- a/v4/packages/kubeintellect-server/app/agent/playbooks/tls_certificate_expiry.yaml
+++ b/v4/packages/kubeintellect-server/app/agent/playbooks/tls_certificate_expiry.yaml
@@ -1,0 +1,30 @@
+name: TLSCertificateExpiry
+triggers:
+  - event_reason_regex: "Failed|Unhealthy|BackOff"
+  - event_message_regex: "x509: certificate.*expired|certificate has expired|certificate verify failed|tls: failed to verify certificate|certificate signed by unknown authority|SSL: CERTIFICATE_VERIFY_FAILED"
+investigation_steps:
+  - "kubectl get pods -A -o wide — identify the affected workload and confirm whether the symptom is isolated to one pod, namespace, or cluster-wide."
+  - "kubectl describe pod <POD> -n <NS> — inspect Warning events and container messages for x509, certificate, TLS, or handshake failures."
+  - "kubectl logs <POD> -n <NS> --all-containers --tail=100 — look for certificate expiry, trust-chain, hostname/SAN, or TLS handshake errors."
+  - "If the workload uses a Kubernetes Secret for TLS, inspect its metadata without exposing the private key: kubectl get secret <TLS_SECRET> -n <NS> -o jsonpath='{.type} {.metadata.creationTimestamp} {.metadata.annotations}'"
+  - "For a TLS secret, decode only the certificate and inspect its validity: kubectl get secret <TLS_SECRET> -n <NS> -o jsonpath='{.data.tls\\.crt}' | base64 -d | openssl x509 -noout -subject -issuer -dates -ext subjectAltName"
+  - "If the certificate is issued by cert-manager, check the Certificate and CertificateRequest resources: kubectl get certificate,certificaterequest -n <NS> and kubectl describe certificate <CERTIFICATE> -n <NS>."
+  - "If the failing endpoint is external, verify the presented certificate and chain from a trusted client: openssl s_client -connect <HOST>:<PORT> -servername <HOST> -showcerts </dev/null"
+  - "Compare the certificate hostname/SAN with the endpoint the client actually uses; an unexpired certificate can still fail verification when its SAN does not cover the requested hostname."
+expected_evidence:
+  - "Certificate validity dates showing that notAfter is in the past or close to expiry"
+  - "Application or Kubernetes event containing an x509, certificate, TLS handshake, or CERTIFICATE_VERIFY_FAILED error"
+  - "TLS Secret containing an expired certificate, or cert-manager Certificate reporting a failed renewal"
+  - "Certificate SAN/hostname mismatch or an incomplete/untrusted issuer chain"
+  - "Absence check: if the certificate is valid and the chain/SAN are correct, investigate trust-store configuration, clock skew, or a different TLS endpoint before rotating credentials"
+recommended_fix_template: |
+  The workload's TLS failure points at <CAUSE>.
+
+  - Expired certificate: renew or rotate the certificate through the system that owns it (for example cert-manager), then restart/reload the affected workload only if it does not hot-reload certificates.
+  - Renewal failure: inspect the Certificate/CertificateRequest events and issuer configuration, then fix the issuer or ACME/DNS/HTTP validation path before retrying renewal.
+  - Wrong hostname/SAN: issue a certificate containing the hostname actually used by the client.
+  - Untrusted or incomplete chain: configure the server to present the required intermediate certificates and ensure the client trust store contains the intended root CA.
+  - Clock skew: correct the node or workload clock before changing certificates.
+
+  Do NOT copy private keys into logs or tickets. Certificate rotation is a
+  mutating operation and must be presented to the operator for human approval.

--- a/v4/tests/test_every_playbook_is_reachable.py
+++ b/v4/tests/test_every_playbook_is_reachable.py
@@ -18,10 +18,10 @@ passes the schema check, and `match_playbooks` iterates it forever without ever 
 `pb.triggers` is a non-empty tuple, so the `if not pb.triggers: continue` guard does not fire
 either. The loader now warns; this file makes it fail.
 
-`test_playbooks.py` checks specific playbooks against hand-written kubectl fixtures, which is
-the right test for *what* each one matches. It cannot cover a playbook nobody wrote a fixture
-for. This one derives its input from each trigger's own regex, so a new playbook is covered the
-moment it is added.
+`test_playbooks.py` checks specific playbooks against hand-written kubectl fixtures, which is the
+right test for *what* each one matches. It cannot cover a playbook nobody wrote a fixture for.
+This one derives its input from each trigger's own regex, so a new playbook is covered the moment
+it is added.
 """
 from __future__ import annotations
 
@@ -115,10 +115,10 @@ _BUMP_HINT = (
 
 def test_the_inventory_is_actually_covered():
     """Guard the guard: an empty registry would make both tests above pass vacuously."""
-    assert len(_PLAYBOOKS) == 26, (
+    assert len(_PLAYBOOKS) == 27, (
         f"playbook count changed to {len(_PLAYBOOKS)}{_BUMP_HINT}"
     )
-    assert len(_CASES) == 46, (
+    assert len(_CASES) == 48, (
         f"trigger-regex count changed to {len(_CASES)}{_BUMP_HINT}"
     )
 

--- a/v4/tests/test_tls_certificate_expiry.py
+++ b/v4/tests/test_tls_certificate_expiry.py
@@ -1,0 +1,36 @@
+"""Tests for the TLS certificate expiry playbook."""
+from __future__ import annotations
+
+from app.agent.playbooks import get_playbook, match_playbooks
+
+HEALTHY_PODS = """\
+NAMESPACE   NAME    READY   STATUS    RESTARTS   AGE
+default     app-1   1/1     Running   0          2h
+"""
+
+TLS_FAILURE_EVENTS = """\
+NAMESPACE   LAST SEEN   TYPE      REASON      OBJECT      MESSAGE
+default     30s         Warning   Unhealthy   pod/app-1   Get "https://api.example.com/health": x509: certificate has expired or is not yet valid
+"""
+
+
+def test_tls_certificate_expiry_matches_certificate_failure() -> None:
+    matched = match_playbooks(HEALTHY_PODS, TLS_FAILURE_EVENTS)
+    assert "TLSCertificateExpiry" in matched
+
+
+def test_tls_certificate_expiry_playbook_has_required_schema() -> None:
+    pb = get_playbook("TLSCertificateExpiry")
+    assert pb is not None
+    assert pb.triggers
+    assert pb.investigation_steps
+    assert pb.expected_evidence
+    assert pb.recommended_fix_template
+
+
+def test_tls_certificate_expiry_does_not_match_healthy_events() -> None:
+    events = """\
+NAMESPACE   LAST SEEN   TYPE      REASON             OBJECT      MESSAGE
+default     30s         Normal    Pulled             pod/app-1   Successfully pulled image
+"""
+    assert "TLSCertificateExpiry" not in match_playbooks(HEALTHY_PODS, events)


### PR DESCRIPTION
## Summary

Implements #13 by adding a Kubernetes TLS/certificate-expiry failure playbook and focused tests.

### Changes
- Add `TLSCertificateExpiry` playbook with triggers for common x509/TLS certificate failures.
- Add investigation steps covering pod events/logs, TLS Secrets, cert-manager resources, external endpoints, SAN/hostname validation, and trust chains.
- Keep remediation human-approved and explicitly avoid exposing private keys.
- Add focused matching/schema/negative tests.
- Update the playbook inventory guard from 26 → 27 playbooks and 46 → 48 trigger regexes.

### Validation
- New tests cover positive certificate-expiry matching, schema completeness, and a healthy-event negative case.
- Inventory guard updated as required for a new playbook.

Signed-off-by: Rahul Kumar <krahul088176@gmail.com>