### PR TITLE
fix(encoding): subprocess.run(..., text=True) decoded with the locale encoding too

### DIFF
--- a/scripts/check-contributor-roster.py
+++ b/scripts/check-contributor-roster.py
@@ -63,7 +63,7 @@ def repo_root() -> str:
     return subprocess.run(  # noqa: S603
         ["git", "rev-parse", "--show-toplevel"],  # noqa: S607
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8",
         check=True,
     ).stdout.strip()
 

--- a/scripts/check-required-checks.py
+++ b/scripts/check-required-checks.py
@@ -60,7 +60,7 @@ def live_protection() -> dict | None:
     try:
         out = subprocess.run(
             ["gh", "api", f"repos/{REPO}/branches/main/protection"],
-            capture_output=True, text=True, timeout=30, check=False,
+            capture_output=True, text=True, encoding="utf-8", timeout=30, check=False,
         )
     except (FileNotFoundError, subprocess.SubprocessError):
         return None

--- a/scripts/check-syntax-warnings.py
+++ b/scripts/check-syntax-warnings.py
@@ -61,7 +61,7 @@ def repo_root() -> str:
         ["git", "rev-parse", "--show-toplevel"],
         capture_output=True,
         check=True,
-        text=True,
+        text=True, encoding="utf-8",
     ).stdout.strip()
 
 
@@ -81,7 +81,7 @@ def tracked_python_files(root: str | None = None) -> list[str]:
         ["git", "ls-files", "-z", "--", "*.py"],
         capture_output=True,
         check=True,
-        text=True,
+        text=True, encoding="utf-8",
         cwd=root,
     ).stdout
     paths = [p for p in out.split("\0") if p]

--- a/scripts/check-text-encoding.py
+++ b/scripts/check-text-encoding.py
@@ -36,8 +36,14 @@
 # It DOES flag a source file that is not valid UTF-8, rather than skipping it: a
 # file the gate cannot read is a file the gate is not guarding.
 #
-# NOT COVERED, and tracked separately: `subprocess.run(..., text=True)` decodes
-# with the locale encoding too. Same bug class, different call shape.
+# subprocess text mode decodes the child's pipes with the locale default too.
+# The `errors=` convention for these calls, as agreed in #168:
+#   - `errors="replace"` where the decoded bytes are free-form **content** a human or
+#     the model will read.
+#   - strict (no `errors=` or `"strict"`) where they are an **identifier**, a **path**,
+#     or a tool's own **structured output**.
+
+
 #
 # SCOPE
 #
@@ -52,6 +58,8 @@
 #   make check-encoding                         # same as the first form
 # ─────────────────────────────────────────────────────────────────────────────
 from __future__ import annotations
+
+SUBPROCESS_CALLS = frozenset({"run", "Popen", "check_output", "call", "check_call"})
 
 import ast
 import subprocess
@@ -93,7 +101,7 @@ def repo_root() -> str:
         ["git", "rev-parse", "--show-toplevel"],
         capture_output=True,
         check=True,
-        text=True,
+        text=True, encoding="utf-8",
     ).stdout.strip()
 
 
@@ -109,7 +117,7 @@ def tracked_python_files(root: str | None = None) -> list[str]:
         ["git", "ls-files", "-z", "--", "*.py"],
         capture_output=True,
         check=True,
-        text=True,
+        text=True, encoding="utf-8",
         cwd=root,
     ).stdout
     paths = [p for p in out.split("\0") if p]
@@ -191,6 +199,17 @@ def offenders(source: str, path: str) -> list[tuple[str, int, str]]:
         if not isinstance(node, ast.Call):
             continue
         name = _called_name(node)
+        
+        # Check subprocess text mode
+        if name in SUBPROCESS_CALLS:
+            text_arg = next((kw for kw in node.keywords if kw.arg in ("text", "universal_newlines")), None)
+            if text_arg:
+                if isinstance(text_arg.value, ast.Constant) and text_arg.value.value is False:
+                    pass  # Explicitly False is fine
+                elif not any(keyword.arg == "encoding" for keyword in node.keywords) and not any(keyword.arg is None for keyword in node.keywords):
+                    found.append((path, node.lineno, name))
+            continue
+            
         if name not in TEXT_IO_NAMES:
             continue
         if any(keyword.arg == "encoding" for keyword in node.keywords):

--- a/v4/packages/kubeintellect-server/app/agent/nodes/context_fetcher.py
+++ b/v4/packages/kubeintellect-server/app/agent/nodes/context_fetcher.py
@@ -187,7 +187,7 @@ def _kubectl_snapshot(args: list[str]) -> tuple[bool, str]:
         proc = subprocess.run(
             ["kubectl"] + args,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8",
             timeout=settings.KUBECTL_TIMEOUT_SECONDS,
             env=env,
             shell=False,

--- a/v4/packages/kubeintellect-server/app/agent/nodes/context_fetcher.py
+++ b/v4/packages/kubeintellect-server/app/agent/nodes/context_fetcher.py
@@ -187,7 +187,7 @@ def _kubectl_snapshot(args: list[str]) -> tuple[bool, str]:
         proc = subprocess.run(
             ["kubectl"] + args,
             capture_output=True,
-            text=True, encoding="utf-8",
+            text=True, encoding="utf-8", errors="replace",
             timeout=settings.KUBECTL_TIMEOUT_SECONDS,
             env=env,
             shell=False,

--- a/v4/packages/kubeintellect-server/app/api/v1/endpoints/namespaces.py
+++ b/v4/packages/kubeintellect-server/app/api/v1/endpoints/namespaces.py
@@ -60,7 +60,7 @@ def list_namespaces() -> NamespacesResponse:
         proc = subprocess.run(
             args,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8",
             timeout=10,
             env=env,
             shell=False,

--- a/v4/packages/kubeintellect-server/app/cli.py
+++ b/v4/packages/kubeintellect-server/app/cli.py
@@ -442,7 +442,7 @@ def _run_quietly(cmd: list[str], timeout: int = 300) -> tuple[bool, str]:
     or a hung call is a failure like any other, not a traceback out of a best-effort helper.
     """
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        proc = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", timeout=timeout)
     except (OSError, subprocess.TimeoutExpired) as exc:
         return False, f"{cmd[0]}: {exc}"
     return proc.returncode == 0, (proc.stderr or proc.stdout).strip()
@@ -453,7 +453,7 @@ def _get_kind_node_ip() -> str:
         result = subprocess.run(
             ["kubectl", "get", "nodes", "-o",
              "jsonpath={.items[0].status.addresses[?(@.type==\"InternalIP\")].address}"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True, text=True, encoding="utf-8", timeout=10,
         )
         return result.stdout.strip()
     except Exception:
@@ -700,7 +700,7 @@ def _install_service() -> _ServiceInstall:
     is told the server starts on login; it does not, and the message that said so is gone.
     """
     kubeintellect_bin = subprocess.run(
-        ["which", "kubeintellect"], capture_output=True, text=True,
+        ["which", "kubeintellect"], capture_output=True, text=True, encoding="utf-8",
     ).stdout.strip() or str(Path(sys.executable).parent / "kubeintellect")
 
     _SERVICE_DIR.mkdir(parents=True, exist_ok=True)
@@ -726,7 +726,7 @@ WantedBy=default.target
         ["systemctl", "--user", "enable", "--now", _SERVICE_NAME],
     ):
         try:
-            proc = subprocess.run(command, capture_output=True, text=True, timeout=30)
+            proc = subprocess.run(command, capture_output=True, text=True, encoding="utf-8", timeout=30)
         except (OSError, subprocess.TimeoutExpired) as exc:
             return _ServiceInstall(False, f"{' '.join(command)}: {exc}")
         if proc.returncode != 0:
@@ -2197,7 +2197,7 @@ def _get_kube_dns_ip() -> str:
         result = subprocess.run(
             ["kubectl", "get", "svc", "kube-dns", "-n", "kube-system",
              "-o", "jsonpath={.spec.clusterIP}"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True, text=True, encoding="utf-8", timeout=5,
         )
         return result.stdout.strip() if result.returncode == 0 else ""
     except Exception:
@@ -2212,7 +2212,7 @@ def cmd_kind_setup(args: argparse.Namespace) -> None:
     _ensure_tool("kubectl", _install_kubectl)
     _ensure_tool("helm",    _install_helm)
 
-    result = subprocess.run(["kind", "get", "clusters"], capture_output=True, text=True)
+    result = subprocess.run(["kind", "get", "clusters"], capture_output=True, text=True, encoding="utf-8",)
     existing = result.stdout.strip().splitlines()
     if cluster_name in existing:
         print(f"  {_ok('✓')}  Kind cluster '{cluster_name}' already exists — skipping creation.")
@@ -2220,7 +2220,7 @@ def cmd_kind_setup(args: argparse.Namespace) -> None:
         print(f"  Creating Kind cluster '{cluster_name}'...")
         result = subprocess.run(
             ["kind", "create", "cluster", "--name", cluster_name],
-            check=False, text=True,
+            check=False, text=True, encoding="utf-8",
         )
         if result.returncode != 0:
             print(_err("  Error: failed to create Kind cluster."), file=sys.stderr)
@@ -2233,7 +2233,7 @@ def cmd_kind_setup(args: argparse.Namespace) -> None:
             "https://raw.githubusercontent.com/kubernetes/ingress-nginx"
             "/main/deploy/static/provider/kind/deploy.yaml"
         )
-        result = subprocess.run(["kubectl", "apply", "-f", ingress_url], check=False, text=True)
+        result = subprocess.run(["kubectl", "apply", "-f", ingress_url], check=False, text=True, encoding="utf-8",)
         if result.returncode != 0:
             print(_warn("  Warning: nginx ingress install failed — install it manually later."), file=sys.stderr)
         else:
@@ -2370,7 +2370,7 @@ def _cluster_reachable(kube_path: str) -> bool | None:
     try:
         result = subprocess.run(
             ["kubectl", "--kubeconfig", kube_path, "version", "-o", "json", "--request-timeout=3s"],
-            capture_output=True, text=True, timeout=8,
+            capture_output=True, text=True, encoding="utf-8", timeout=8,
         )
     except FileNotFoundError:
         return None                      # no kubectl — the file check is all we can honestly report
@@ -2383,7 +2383,7 @@ def _get_kube_context(kube_path: str) -> str:
     try:
         result = subprocess.run(
             ["kubectl", "--kubeconfig", kube_path, "config", "current-context"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True, text=True, encoding="utf-8", timeout=5,
         )
         return result.stdout.strip() if result.returncode == 0 else ""
     except Exception:

--- a/v4/packages/kubeintellect-server/app/cluster_id.py
+++ b/v4/packages/kubeintellect-server/app/cluster_id.py
@@ -53,7 +53,7 @@ def _kubectl(args: list[str], timeout: int = 5) -> str:
         proc = subprocess.run(
             ["kubectl"] + args,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8",
             timeout=timeout,
             env=env,
             shell=False,

--- a/v4/packages/kubeintellect-server/app/tools/aci/gitops.py
+++ b/v4/packages/kubeintellect-server/app/tools/aci/gitops.py
@@ -34,7 +34,12 @@ def _default_runner(argv: list[str]) -> tuple[int, str]:
     import subprocess
     try:
         r = subprocess.run(
-            argv, capture_output=True, text=True, encoding="utf-8", timeout=_DEFAULT_TIMEOUT_S
+            argv,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_DEFAULT_TIMEOUT_S,
         )
     except subprocess.TimeoutExpired:
         # Non-zero + a readable reason: push failure surfaces to the caller, and a `gh` timeout

--- a/v4/packages/kubeintellect-server/app/tools/aci/gitops.py
+++ b/v4/packages/kubeintellect-server/app/tools/aci/gitops.py
@@ -34,7 +34,7 @@ def _default_runner(argv: list[str]) -> tuple[int, str]:
     import subprocess
     try:
         r = subprocess.run(
-            argv, capture_output=True, text=True, timeout=_DEFAULT_TIMEOUT_S
+            argv, capture_output=True, text=True, encoding="utf-8", timeout=_DEFAULT_TIMEOUT_S
         )
     except subprocess.TimeoutExpired:
         # Non-zero + a readable reason: push failure surfaces to the caller, and a `gh` timeout

--- a/v4/packages/kubeintellect-server/app/tools/helm_tool.py
+++ b/v4/packages/kubeintellect-server/app/tools/helm_tool.py
@@ -323,7 +323,7 @@ def run_helm(command: str) -> str:
         proc = subprocess.run(
             tokens,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8",
             timeout=30,
         )
     except FileNotFoundError:

--- a/v4/packages/kubeintellect-server/app/tools/helm_tool.py
+++ b/v4/packages/kubeintellect-server/app/tools/helm_tool.py
@@ -323,7 +323,7 @@ def run_helm(command: str) -> str:
         proc = subprocess.run(
             tokens,
             capture_output=True,
-            text=True, encoding="utf-8",
+            text=True, encoding="utf-8", errors="replace",
             timeout=30,
         )
     except FileNotFoundError:

--- a/v4/packages/kubeintellect-server/app/tools/kubectl_tool.py
+++ b/v4/packages/kubeintellect-server/app/tools/kubectl_tool.py
@@ -1394,7 +1394,7 @@ def _capture_rollback_point(verb: str, args: list, stdin: str | None, config, en
             label = " ".join(target[2:4])
             try:
                 pre = subprocess.run(
-                    target, capture_output=True, text=True, timeout=5, env=env, shell=False
+                    target, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5, env=env, shell=False
                 )
                 if pre.returncode == 0 and pre.stdout:
                     kept = redact_secrets(pre.stdout, max_chars=_ROLLBACK_MAX_CHARS)
@@ -1677,11 +1677,16 @@ def run_kubectl(
         else settings.KUBECTL_TIMEOUT_SECONDS
     )
     try:
+        # Decode free-form content lossily to survive non-ASCII log lines;
+        # decode identifiers and structured output strictly to avoid plausible wrong answers.
+        decode_errors = "replace" if verb in ("logs", "describe", "get") else "strict"
         proc = subprocess.run(
             args,
             input=stdin,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors=decode_errors,
             timeout=timeout,
             env=env,
             shell=False,

--- a/v4/scripts/aci_sandbox_probe.py
+++ b/v4/scripts/aci_sandbox_probe.py
@@ -31,7 +31,7 @@ def _kubectl(argstr: str) -> str:
     args = shlex.split(argstr)
     if args and args[0] == "kubectl":
         args = args[1:]
-    r = subprocess.run(["kubectl", *args], capture_output=True, text=True, env=env)
+    r = subprocess.run(["kubectl", *args], capture_output=True, text=True, encoding="utf-8", errors="replace", env=env)
     return (r.stdout + r.stderr).strip()
 
 

--- a/v4/scripts/aci_token_ab.py
+++ b/v4/scripts/aci_token_ab.py
@@ -32,7 +32,7 @@ def toks(s: str) -> int:
 def _raw(cmd: str) -> str:
     """TRUE unbounded kubectl output — what a naive 'dump stdout' tool costs."""
     env = {**os.environ, "KUBECONFIG": os.path.expanduser(os.environ["KUBECONFIG_PATH"])}
-    p = subprocess.run(shlex.split(cmd), capture_output=True, text=True, env=env, timeout=30)
+    p = subprocess.run(shlex.split(cmd), capture_output=True, text=True, encoding="utf-8", errors="replace", env=env, timeout=30)
     return p.stdout or p.stderr or "(no output)"
 
 

--- a/v4/scripts/check_doc_claims.py
+++ b/v4/scripts/check_doc_claims.py
@@ -133,7 +133,7 @@ def _files_this_tree_ships(rootdir: Path, subdir: str, pattern: str) -> set[Path
             ["git", "ls-files", "-z", "--", subdir],
             cwd=rootdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8",
             timeout=60,
         )
     except (OSError, subprocess.TimeoutExpired):
@@ -213,7 +213,7 @@ def _collect_count(rootdir: Path) -> int | None:
             [sys.executable, "-m", "pytest", "--collect-only", "-q", "tests/", *ignores],
             cwd=rootdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8",
             timeout=300,
         )
     except (OSError, subprocess.TimeoutExpired):
@@ -245,7 +245,7 @@ def _format_drift_count() -> int | None:
             [sys.executable, "-m", "ruff", "format", "--check", *sorted(str(p) for p in tracked)],
             cwd=_V4,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8",
             timeout=300,
         )
     except (OSError, subprocess.TimeoutExpired):

--- a/v4/scripts/fix_pr_probe.py
+++ b/v4/scripts/fix_pr_probe.py
@@ -33,7 +33,7 @@ def check(name: str, cond: bool, detail: str = "") -> None:
 
 
 def _git(repo: Path, *args: str) -> str:
-    r = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
+    r = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True, encoding="utf-8", errors="replace",)
     return (r.stdout + r.stderr).strip()
 
 

--- a/v4/scripts/opsmembench_live_probe.py
+++ b/v4/scripts/opsmembench_live_probe.py
@@ -45,7 +45,7 @@ def check(name: str, cond: bool, detail: str = "") -> None:
 
 def _kubectl(cmd: str) -> str:
     env = {**os.environ, "KUBECONFIG": os.path.expanduser(os.environ["KUBECONFIG_PATH"])}
-    return subprocess.run(shlex.split(cmd), capture_output=True, text=True, env=env, timeout=30).stdout
+    return subprocess.run(shlex.split(cmd), capture_output=True, text=True, encoding="utf-8", errors="replace", env=env, timeout=30).stdout
 
 
 def capture_snapshot() -> dict[str, str]:

--- a/v4/tests/test_a_documented_exit_code_is_a_checked_claim.py
+++ b/v4/tests/test_a_documented_exit_code_is_a_checked_claim.py
@@ -113,7 +113,7 @@ def test_the_documented_usage_code_is_the_one_the_command_really_returns(command
         ],
         cwd=_CLI.parents[2],
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8",
         timeout=120,
     )
     assert proc.returncode == 2, proc.stdout + proc.stderr

--- a/v4/tests/test_a_test_can_be_green_only_where_the_private_tier_exists.py
+++ b/v4/tests/test_a_test_can_be_green_only_where_the_private_tier_exists.py
@@ -46,7 +46,7 @@ def _private_only_paths() -> list[str]:
          "ls-tree", "-r", "--name-only", "HEAD"],
         cwd=_REPO_ROOT,
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8",
         check=True,
     )
     private = {line for line in priv.stdout.splitlines() if line}
@@ -60,7 +60,7 @@ def _tracked_at_head() -> list[str]:
         ["git", "ls-tree", "-r", "--name-only", "HEAD"],
         cwd=_REPO_ROOT,
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8",
         check=True,
     )
     return sorted(line for line in out.stdout.splitlines() if line)
@@ -88,7 +88,7 @@ def export_dir():
             ["bash", str(_SCRIPT), "--export-only", str(target)],
             cwd=_REPO_ROOT,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8",
         )
         assert proc.returncode == 0, (
             f"--export-only failed ({proc.returncode})\n"
@@ -107,7 +107,7 @@ class TestTheScriptIsRunnableAtAll:
         assert _SCRIPT.stat().st_mode & 0o111, f"{_SCRIPT.name} is not executable"
 
     def test_it_parses(self):
-        proc = subprocess.run(["bash", "-n", str(_SCRIPT)], capture_output=True, text=True)
+        proc = subprocess.run(["bash", "-n", str(_SCRIPT)], capture_output=True, text=True, encoding="utf-8",)
         assert proc.returncode == 0, proc.stderr
 
 
@@ -146,7 +146,7 @@ class TestItRunsWhereGitHasNoConfiguredIdentity:
             ["bash", str(_SCRIPT), "--export-only", str(tmp_path / "tree")],
             cwd=_REPO_ROOT,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8",
             env=env,
         )
         assert proc.returncode == 0, (
@@ -157,7 +157,7 @@ class TestItRunsWhereGitHasNoConfiguredIdentity:
             ["git", "rev-parse", "HEAD"],
             cwd=tmp_path / "tree",
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8",
             env=env,
         )
         assert head.returncode == 0, head.stderr
@@ -176,7 +176,7 @@ class TestTheExportIsAFaithfulCheckout:
             ["git", "rev-parse", "--is-inside-work-tree"],
             cwd=export_dir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8",
         )
         assert proc.returncode == 0, proc.stderr
         assert proc.stdout.strip() == "true"
@@ -189,7 +189,7 @@ class TestTheExportIsAFaithfulCheckout:
             ["git", "rev-parse", "HEAD"],
             cwd=export_dir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8",
         )
         assert proc.returncode == 0, f"the export has no HEAD:\n{proc.stderr}"
         assert len(proc.stdout.strip()) == 40
@@ -202,7 +202,7 @@ class TestTheExportIsAFaithfulCheckout:
             ["git", "ls-files"],
             cwd=export_dir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8",
             check=True,
         )
         got = sorted(line for line in out.stdout.splitlines() if line)
@@ -232,7 +232,7 @@ class TestNoPrivateTierPathReachesTheExport:
             ["git", "ls-files"],
             cwd=export_dir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8",
             check=True,
         )
         indexed = {line for line in out.stdout.splitlines() if line}

--- a/v4/tests/test_chart_shutdown_contract.py
+++ b/v4/tests/test_chart_shutdown_contract.py
@@ -137,7 +137,7 @@ class TestTheChartRefusesTheBrokenArithmetic:
     def _render(*overrides: str) -> subprocess.CompletedProcess:
         return subprocess.run(
             ["helm", "template", "contract-test", str(_CHART), *overrides],
-            capture_output=True, text=True, timeout=120,
+            capture_output=True, text=True, encoding="utf-8", timeout=120,
         )
 
     def test_a_drain_longer_than_the_grace_period_is_refused(self):

--- a/v4/tests/test_db_init_reports_failure.py
+++ b/v4/tests/test_db_init_reports_failure.py
@@ -58,7 +58,7 @@ def _shipped_docs() -> list[Path]:
             ["git", "ls-files", "-z", "--", "docs"],
             cwd=_ROOT,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8",
             timeout=60,
         )
         tracked = sorted(_ROOT / name for name in proc.stdout.split("\0") if name.endswith(".md"))

--- a/v4/tests/test_doc_claims.py
+++ b/v4/tests/test_doc_claims.py
@@ -231,7 +231,7 @@ class TestEveryCountClaimIsCovered:
         """Tracked docs only — an untracked scratch file is not a surface anyone reads."""
         proc = subprocess.run(
             ["git", "ls-files", "-z", "--", "v4/docs/*.md", "ROADMAP.md", "README.md"],
-            cwd=_REPO_ROOT, capture_output=True, text=True, timeout=60,
+            cwd=_REPO_ROOT, capture_output=True, text=True, encoding="utf-8", timeout=60,
         )
         return [_REPO_ROOT / name for name in proc.stdout.split("\0") if name]
 

--- a/v4/tests/test_one_tests_import_does_not_change_the_next_tests_environment.py
+++ b/v4/tests/test_one_tests_import_does_not_change_the_next_tests_environment.py
@@ -70,6 +70,6 @@ def test_the_suite_is_not_at_the_mercy_of_a_local_dotenv() -> None:
         [sys.executable, "-m", "pytest", "-q", "-p", "no:randomly",
          "v4/tests/test_evaluation_runner.py",
          "v4/tests/test_every_command_reads_the_same_config.py"],
-        cwd=root, capture_output=True, text=True, timeout=600,
+        cwd=root, capture_output=True, text=True, encoding="utf-8", timeout=600,
     )
     assert p.returncode == 0, p.stdout[-4000:] + p.stderr[-2000:]

--- a/v4/tests/test_pipe_grep_matches_real_grep.py
+++ b/v4/tests/test_pipe_grep_matches_real_grep.py
@@ -81,7 +81,7 @@ SUPPORTED = [
 def test_emulated_grep_equals_real_grep(command):
     """Byte-for-byte, against the binary the emulator is standing in for."""
     import shlex
-    proc = subprocess.run(shlex.split(command), input=LOG, capture_output=True, text=True)
+    proc = subprocess.run(shlex.split(command), input=LOG, capture_output=True, text=True, encoding="utf-8",)
     # grep exits 1 when nothing matched, but `-c` still prints "0" — compare stdout, not the
     # exit code. The emulator has no exit code, so an empty stdout is its "(no matching lines)".
     expected = proc.stdout

--- a/v4/tests/test_rbac_covers_the_playbooks.py
+++ b/v4/tests/test_rbac_covers_the_playbooks.py
@@ -105,7 +105,7 @@ def _granted_for_read() -> set[tuple[str, str]]:
     """(apiGroup, resource) pairs the rendered chart grants `get`/`list` on."""
     proc = subprocess.run(
         ["helm", "template", "rbac-test", str(_CHART)],
-        capture_output=True, text=True, timeout=120,
+        capture_output=True, text=True, encoding="utf-8", timeout=120,
     )
     assert proc.returncode == 0, proc.stderr
     granted: set[tuple[str, str]] = set()

--- a/v4/tests/test_the_file_mode_gate_says_what_it_checked.py
+++ b/v4/tests/test_the_file_mode_gate_says_what_it_checked.py
@@ -42,13 +42,13 @@ def _git(repo: Path, *args: str, git_dir: str | None = None) -> subprocess.Compl
     if git_dir is not None:
         env["GIT_DIR"] = git_dir
     return subprocess.run(
-        ["git", *args], cwd=repo, env=env, capture_output=True, text=True, check=True
+        ["git", *args], cwd=repo, env=env, capture_output=True, text=True, encoding="utf-8", check=True
     )
 
 
 def _run(repo: Path, *args: str) -> subprocess.CompletedProcess:
     return subprocess.run(
-        ["bash", str(_SCRIPT), *args], cwd=repo, capture_output=True, text=True
+        ["bash", str(_SCRIPT), *args], cwd=repo, capture_output=True, text=True, encoding="utf-8",
     )
 
 

--- a/v4/tests/test_the_lint_gate_covers_the_tree.py
+++ b/v4/tests/test_the_lint_gate_covers_the_tree.py
@@ -36,7 +36,7 @@ def _lint_paths() -> list[str]:
 
 def _tracked_python() -> list[str]:
     proc = subprocess.run(
-        ["git", "ls-files", "-z", "--", "."], cwd=_V4, capture_output=True, text=True, timeout=60
+        ["git", "ls-files", "-z", "--", "."], cwd=_V4, capture_output=True, text=True, encoding="utf-8", timeout=60
     )
     return [name for name in proc.stdout.split("\0") if name.endswith(".py")]
 

--- a/v4/tests/test_the_skip_note_survives_bad_news.py
+++ b/v4/tests/test_the_skip_note_survives_bad_news.py
@@ -49,12 +49,12 @@ NOTE = "tracked path(s) were skipped"
 
 def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
     return subprocess.run(["git", *args], cwd=repo, env=dict(os.environ),
-                          capture_output=True, text=True, check=True)
+                          capture_output=True, text=True, encoding="utf-8", check=True)
 
 
 def _run(repo: Path, *args: str) -> subprocess.CompletedProcess:
     return subprocess.run(["bash", str(_SCRIPT), *args], cwd=repo,
-                          capture_output=True, text=True)
+                          capture_output=True, text=True, encoding="utf-8",)
 
 
 def _write(repo: Path, rel: str, body: str, *, executable: bool) -> None:

--- a/v4/tests/test_the_snapshot_is_not_a_second_cluster.py
+++ b/v4/tests/test_the_snapshot_is_not_a_second_cluster.py
@@ -345,7 +345,7 @@ class TestTheCaseListDoesNotDependOnTheEnvironment:
                     __file__,
                 ],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8",
                 timeout=300,
                 env={**os.environ, "KUBECTL_BLOCKED_NAMESPACES": blocklist},
             )


### PR DESCRIPTION
Closes #168.

`subprocess.run(..., text=True)` decodes the child's pipes with the platform default.
Structured or identifying output now decodes strictly (`encoding="utf-8"`); free-form human-read text uses `errors="replace"`.